### PR TITLE
fix: add missing pckg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-discord",
-  "version": "1.0.0-beta.53",
+  "version": "1.0.0-beta.54",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -25,8 +25,9 @@
     "@discordjs/opus": "^0.10.0",
     "@discordjs/rest": "2.4.0",
     "@discordjs/voice": "0.18.0",
-    "@elizaos/core": "^1.0.0-beta.52",
+    "@elizaos/core": "^1.0.0-beta",
     "discord.js": "14.16.3",
+    "fluent-ffmpeg": "^2.1.3",
     "get-func-name": "^3.0.0",
     "node-opus": "^0.3.3",
     "opusscript": "^0.1.1",


### PR DESCRIPTION
## Problem

When running the ElizaOS CLI, the Discord plugin fails to load due to a missing dependency error:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'fluent-ffmpeg' imported from /app/packages/plugin-discord/dist/index.js
```

## Root Cause

The Discord plugin imports and uses `fluent-ffmpeg` for audio processing (as seen in `src/attachments.ts`), but this package was not declared as a dependency in the `package.json` file. This causes runtime errors when the CLI tries to import the plugin.

## Solution

This PR adds `fluent-ffmpeg` as a dependency to the Discord plugin's `package.json` to resolve the import error and ensure the plugin can be properly loaded by the ElizaOS CLI.

## Changes

- Added `fluent-ffmpeg` to the dependencies in `package.json`
- This ensures the package is available when the plugin is imported and used

## Testing

After this change, the Discord plugin should load without the module not found error when running the ElizaOS CLI.

---

Fixes the CLI import issue where `fluent-ffmpeg` package could not be found during plugin initialization.