### PR TITLE
fix: enable replies in threads and to bots

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -279,15 +279,41 @@ export class DiscordService extends Service implements IDiscordService {
     }
 
     // Setup handling for direct messages
-    this.client.on('messageCreate', (message) => {
+    this.client.on("messageCreate", async (message) => {
       // Skip if we're sending the message or in deleted state
-      if (message.author.id === this.client?.user?.id || message.author.bot) {
+      if (
+        message.author.id === this.client?.user?.id ||
+        (message.author.bot && this.runtime.character.settings?.discord?.shouldIgnoreBotMessages)
+      ) {
+        logger.info(
+          `Got message where author is ${message.author.bot && this.runtime.character.settings?.discord?.shouldIgnoreBotMessages
+            ? "a bot. To reply anyway, set \`shouldIgnoreBotMessages=true\`."
+            : "the current user. Ignore!"}`
+        );
         return;
       }
 
       // Skip if channel restrictions are set and this channel is not allowed
       if (this.allowedChannelIds && !this.allowedChannelIds.includes(message.channel.id)) {
-        return;
+        // check first whether the channe is a thread...
+        const channel = await this.client?.channels.fetch(message.channel.id);
+
+        if (!channel) {
+          logger.error(`Channel id ${message.channel.id} not found. Ignore!`);
+          return;
+        }
+        if (channel.isThread()) {
+          if (
+            !channel.parentId ||
+            !this.allowedChannelIds.includes(channel.parentId)
+          ) {
+            logger.info(`Thread not in an allowed channel. Add the channel ${channel.parentId} to CHANNEL_IDS to enable replies.`);
+            return;
+          }
+        } else {
+          logger.info(`Channel not allowed. Add the channel ${message.channel.id} to CHANNEL_IDS to enable replies.`);
+          return;
+        }
       }
 
       try {


### PR DESCRIPTION
This commit enables bot-bot interaction, and replies in threads.

It fixes in particular these two issues:
a) not prematurely skip handling messages if shouldIgnoreBotMessages is not set or set to false
b) check whether the message was sent in a thread, and if so checks whether the parent channel is an allowed channel

Before this fix, replies in threads would be possible if NO CHANNEL_IDS were set (all channels allowed), but otherwise always disabled.
Bot-bot interaction was always disabled.