### PR TITLE
fix: scope chat with attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-discord",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -25,7 +25,7 @@
     "@discordjs/opus": "^0.10.0",
     "@discordjs/rest": "2.4.3",
     "@discordjs/voice": "0.18.0",
-    "@elizaos/core": "^1.0.0",
+    "@elizaos/core": "^1.0.4",
     "discord.js": "14.18.0",
     "fluent-ffmpeg": "^2.1.3",
     "get-func-name": "^3.0.0",

--- a/src/actions/chatWithAttachments.ts
+++ b/src/actions/chatWithAttachments.ts
@@ -116,9 +116,12 @@ export const chatWithAttachments: Action = {
     "Answer a user request informed by specific attachments based on their IDs. If a user asks to chat with a PDF, or wants more specific information about a link or video or anything else they've attached, this is the action to use.",
   validate: async (_runtime: IAgentRuntime, message: Memory, _state: State) => {
     const room = await _runtime.getRoom(message.roomId);
-    if (room?.type !== ChannelType.GROUP) {
+
+    // Only validate for Discord GROUP channels - this action is Discord-specific
+    if (room?.type !== ChannelType.GROUP || room?.source !== 'discord') {
       return false;
     }
+
     // only show if one of the keywords are in the message
     const keywords: string[] = [
       'attachment',


### PR DESCRIPTION
## Description

This PR scopes the chat with attachments action to only work within Discord contexts.

## Problem

The Discord attachment handling action was being triggered across all platforms, causing interference with other platform integrations. The agent should only call platform-specific actions when messages originate from that specific platform.

## Solution

- Added platform validation to ensure the attachment handling action only executes for Discord messages
- Prevents cross-platform interference by checking the message source before processing attachments

## Impact

- ✅ Discord attachment handling remains fully functional
- ✅ Other platforms no longer trigger Discord-specific attachment processing
- ✅ Improved platform isolation and reduced unintended behavior