### PR TITLE
fix: ensure typing indicator appears before message processing

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -172,6 +172,9 @@ export class MessageManager {
         cleared: false,
       };
 
+      // Add a small delay to ensure typing indicator appears before processing
+      await new Promise(resolve => setTimeout(resolve, 200));
+
       const newMessage: Memory = {
         id: messageId,
         entityId: entityId,


### PR DESCRIPTION
### 🐛 **Problem**
The Discord bot's typing indicator was appearing **after** the message was already sent, creating an unnatural conversation flow where users would see the response before seeing that the bot was "thinking".

### 🔍 **Root Cause**
The typing indicator was started immediately but the message processing and response generation happened synchronously without giving Discord enough time to display the typing indicator to users.

### ✅ **Solution**
Added a 200ms delay after starting the typing indicator to ensure it becomes visible before message processing begins:

```typescript
// Add a small delay to ensure typing indicator appears before processing
await new Promise(resolve => setTimeout(resolve, 200));
```

### 📍 **Changes Made**
- **File**: `plugin-discord/src/messages.ts`
- **Line**: 171 (added delay after typing indicator start)
- **Impact**: Minimal change, only affects timing flow

### 🧪 **Testing**
- [x] Typing indicator now appears before bot responses
- [x] No impact on message processing functionality
- [x] No breaking changes to existing behavior
- [x] Error handling remains intact

### 📝 **Technical Details**
- Uses `Promise` with `setTimeout` for non-blocking delay
- Minimal performance impact (200ms delay)
- Typing indicator cleanup logic unchanged
- Compatible with existing timeout mechanisms

### 🔄 **Breaking Changes**
None - this is a pure enhancement that doesn't modify any APIs or existing functionality.