### PR TITLE
fix: typing-indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-discord",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -223,7 +223,7 @@ export class MessageManager {
             content.inReplyTo = createUniqueUuid(this.runtime, message.id);
           }
 
-          let messages: DiscordMessage[] = [];
+          let messages: any[] = [];
           if (content?.source === "DM") {
             const u = await this.client.users.fetch(message.author.id);
             if (!u) {
@@ -231,7 +231,7 @@ export class MessageManager {
               return [];
             }
             await u.send(content.text || "");
-            messages = [message]; // Use original message as reference
+            messages = [content];
           } else {
             messages = await sendMessageInChunks(
               channel,

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -174,6 +174,13 @@ export class MessageManager {
         cleared: false,
       };
 
+      // Start typing indicator immediately when we begin processing the message
+      startTyping();
+      
+      // Create interval to keep the typing indicator active while processing
+      const typingInterval = setInterval(startTyping, 8000);
+      typingData.interval = typingInterval;
+
       // Add a small delay to ensure typing indicator appears before processing
       await new Promise(resolve => setTimeout(resolve, 200));
 
@@ -212,28 +219,19 @@ export class MessageManager {
         files: Array<{ attachment: Buffer | string; name: string }>
       ) => {
         try {
-          // Initial typing indicator
-          startTyping();
-
-          // Create interval to keep the typing indicator active
-          const typingInterval = setInterval(startTyping, 8000);
-
-          typingData.interval = typingInterval;
-          typingData.cleared = false;
-
           if (message.id && !content.inReplyTo) {
             content.inReplyTo = createUniqueUuid(this.runtime, message.id);
           }
 
-          let messages = [];
+          let messages: DiscordMessage[] = [];
           if (content?.source === "DM") {
             const u = await this.client.users.fetch(message.author.id);
             if (!u) {
               logger.warn("Discord - User not found", message.author.id);
               return [];
             }
-            u.send(content.text);
-            messages = [content];
+            await u.send(content.text || "");
+            messages = [message]; // Use original message as reference
           } else {
             messages = await sendMessageInChunks(
               channel,
@@ -268,7 +266,7 @@ export class MessageManager {
             await this.runtime.createMemory(m, "messages");
           }
 
-          // Clear typing indicator
+          // Clear typing indicator when done
           if (typingData.interval && !typingData.cleared) {
             clearInterval(typingData.interval);
             typingData.cleared = true;
@@ -277,6 +275,7 @@ export class MessageManager {
           return memories;
         } catch (error) {
           console.error("Error handling message:", error);
+          // Clear typing indicator on error
           if (typingData.interval && !typingData.cleared) {
             clearInterval(typingData.interval);
             typingData.cleared = true;
@@ -294,12 +293,13 @@ export class MessageManager {
         }
       );
 
+      // Failsafe: clear typing indicator after 30 seconds if something goes wrong
       setTimeout(() => {
         if (typingData.interval && !typingData.cleared) {
           clearInterval(typingData.interval);
           typingData.cleared = true;
         }
-      }, 500);
+      }, 30000);
     } catch (error) {
       console.error("Error handling message:", error);
     }


### PR DESCRIPTION
## Problem
Discord typing indicator ("Bot is typing...") wasn't showing when users sent messages to the agent, creating poor UX with no feedback during message processing.

## Root Cause  
Typing indicator was only triggered **inside the response callback** (when ready to respond), not when message processing began.

**Before:**
```javascript
const callback = async () => {
  startTyping(); // ❌ Too late - only when ready to respond
  // Generate response...
}
```

## Solution
- **Start typing immediately** when message processing begins
- **Maintain typing** with 8-second refresh intervals during processing  
- **Clean up properly** when response is sent or error occurs
- **Failsafe timeout** after 30 seconds to prevent stuck indicators

**After:**
```javascript
// ✅ Start typing immediately when processing begins
startTyping();
const typingInterval = setInterval(startTyping, 8000);

const callback = async () => {
  // Generate response...
  clearInterval(typingInterval); // ✅ Clean up when done
}
```

## Impact
- **Better UX**: Users see immediate feedback that their message was received
- **No stuck indicators**: Proper cleanup prevents infinite typing states

## Files Changed
- `plugin-discord/src/messages.ts` - Enhanced typing indicator logic