### PR TITLE
chore: add renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate config for @elizaos/plugin-discord",
+  "extends": ["github>elizaOS/eliza:.github/renovate-preset"],
+  "packageRules": [
+    {
+      "description": "Group Discord.js ecosystem updates specific to this plugin",
+      "groupName": "Discord.js",
+      "matchPackagePatterns": ["^@discordjs/", "^discord.js"]
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a Renovate configuration that extends a shared preset.
  * Groups Discord.js ecosystem dependency updates into a single “Discord.js” group with clear labeling.
  * Streamlines dependency update PRs, reducing noise and making reviews more efficient.
  * No user-facing changes or behavior impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->