### PR TITLE
fix: Add null check for DISCORD_LISTEN_CHANNEL_IDS setting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@discordjs/opus": "^0.10.0",
         "@discordjs/rest": "2.4.3",
         "@discordjs/voice": "0.18.0",
-        "@elizaos/core": "^1.5.15",
+        "@elizaos/core": "^1.6.1",
         "discord.js": "14.18.0",
         "fast-levenshtein": "^3.0.0",
         "fluent-ffmpeg": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-discord",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -25,7 +25,7 @@
     "@discordjs/opus": "^0.10.0",
     "@discordjs/rest": "2.4.3",
     "@discordjs/voice": "0.18.0",
-    "@elizaos/core": "^1.5.15",
+    "@elizaos/core": "^1.6.1",
     "discord.js": "14.18.0",
     "fast-levenshtein": "^3.0.0",
     "fluent-ffmpeg": "^2.1.3",

--- a/src/service.ts
+++ b/src/service.ts
@@ -289,7 +289,7 @@ export class DiscordService extends Service implements IDiscordService {
       return; // Skip if client is not available
     }
 
-    const listenCidsRaw: string | string[] = this.runtime.getSetting('DISCORD_LISTEN_CHANNEL_IDS');
+    const listenCidsRaw: string | string[] | undefined = this.runtime.getSetting('DISCORD_LISTEN_CHANNEL_IDS');
     const listenCids = Array.isArray(listenCidsRaw)
       ? listenCidsRaw
       : (listenCidsRaw && typeof listenCidsRaw === 'string' && listenCidsRaw.trim())

--- a/src/service.ts
+++ b/src/service.ts
@@ -292,7 +292,9 @@ export class DiscordService extends Service implements IDiscordService {
     const listenCidsRaw: string | string[] = this.runtime.getSetting('DISCORD_LISTEN_CHANNEL_IDS');
     const listenCids = Array.isArray(listenCidsRaw)
       ? listenCidsRaw
-      : listenCidsRaw.trim().split(',').map(s => s.trim()).filter(s => s.length > 0)
+      : (listenCidsRaw && typeof listenCidsRaw === 'string' && listenCidsRaw.trim())
+        ? listenCidsRaw.trim().split(',').map(s => s.trim()).filter(s => s.length > 0)
+        : []
     const talkCids = this.allowedChannelIds ?? [] // CHANNEL_IDS
     const allowedCids = [...listenCids, ...talkCids]
 


### PR DESCRIPTION
## Summary

Fixes the runtime error: `null is not an object (evaluating 'listenCidsRaw.trim')` that occurs when initializing the Discord plugin.

## Problem

The code in `setupEventListeners()` was attempting to call `.trim()` on the `DISCORD_LISTEN_CHANNEL_IDS` setting without checking if the value was `null` or `undefined` first:

```typescript
const listenCidsRaw: string | string[] = this.runtime.getSetting('DISCORD_LISTEN_CHANNEL_IDS');
const listenCids = Array.isArray(listenCidsRaw)
  ? listenCidsRaw
  : listenCidsRaw.trim().split(',').map(s => s.trim()).filter(s => s.length > 0)
```

When `DISCORD_LISTEN_CHANNEL_IDS` is not set in the environment or character settings, `getSetting()` returns `null` or `undefined`, causing the error when trying to call `.trim()` on it.

## Solution

Added proper null/undefined checking before attempting to call `.trim()`:

```typescript
const listenCidsRaw: string | string[] = this.runtime.getSetting('DISCORD_LISTEN_CHANNEL_IDS');
const listenCids = Array.isArray(listenCidsRaw)
  ? listenCidsRaw
  : (listenCidsRaw && typeof listenCidsRaw === 'string' && listenCidsRaw.trim())
    ? listenCidsRaw.trim().split(',').map(s => s.trim()).filter(s => s.length > 0)
    : []
```

Now if the setting is not defined, it safely defaults to an empty array `[]` instead of crashing.

## Test Plan

- [x] Tested with `DISCORD_LISTEN_CHANNEL_IDS` not set - no longer crashes
- [x] Tested with `DISCORD_LISTEN_CHANNEL_IDS` set to valid channel IDs - works as expected
- [x] Tested with empty string - returns empty array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord channel listener handling to avoid errors when channel configuration is missing or invalid; preserves behavior for valid settings and improves stability.

* **Chores**
  * Bumped core dependency to @elizaos/core ^1.6.1 for compatibility and stability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->