### PR TITLE
fix: continue registering commands if one throws

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -1178,6 +1178,9 @@ export class DiscordService extends Service implements IDiscordService {
 
       // Queue this registration to prevent race conditions
       // Each registration waits for the previous one to complete
+      let registrationError: Error | null = null;
+      let registrationFailed = false;
+
       this.commandRegistrationQueue = this.commandRegistrationQueue.then(async () => {
         // Deduplicate commands by name: merge existing and incoming commands into a map
         // Incoming commands overwrite existing ones with the same name
@@ -1207,15 +1210,24 @@ export class DiscordService extends Service implements IDiscordService {
           throw new Error('Discord client application is not available');
         }
       }).catch((error) => {
+        registrationFailed = true;
+        registrationError = error instanceof Error ? error : new Error(String(error));
         this.runtime.logger.error(
-          `Error registering Discord commands: ${error instanceof Error ? error.message : String(error)}`
+          `Error registering Discord commands: ${registrationError.message}`
         );
-        // Re-throw to maintain the promise chain
-        throw error;
+        // Don't re-throw: allow the queue to continue processing future registrations
+        // even if this one failed. The error is logged and will be thrown after queue completes.
       });
 
       // Wait for this registration to complete
       await this.commandRegistrationQueue;
+
+      // Throw error after queue completes if this registration failed
+      // This allows the queue to continue processing future registrations
+      if (registrationFailed && registrationError) {
+        throw registrationError;
+      }
+
       return
     })
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Continues the Discord slash command registration queue even if a registration fails, logging the error and throwing it after the queued step completes.
> 
> - **Discord command registration (`src/service.ts`)**:
>   - Queue now continues on registration errors: catch stores `registrationError`/`registrationFailed`, logs, and does not rethrow inside the queue.
>   - After awaiting the queue, rethrows the captured error to the caller if the step failed.
>   - Maintains deduplication and global registration via `application.commands.set`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 843033571b54250ae524c909ee19bcab7a02f061. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced command registration reliability. Registration failures no longer interrupt the queue, allowing remaining commands to be processed. Errors are still reported after the queue completes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->