### PR TITLE
feat(discord): add tiered permission system for bot invite URLs

### DIFF
--- a/src/actions/getUserInfo.ts
+++ b/src/actions/getUserInfo.ts
@@ -149,7 +149,8 @@ export const getUserInfo: Action = {
 
     try {
       const room = state.data?.room || (await runtime.getRoom(message.roomId));
-      if (!room?.serverId) {
+      const serverId = room?.serverId ?? room?.messageServerId;
+      if (!serverId) {
         await callback({
           text: "I couldn't determine the current server.",
           source: 'discord',
@@ -157,7 +158,7 @@ export const getUserInfo: Action = {
         return;
       }
 
-      const guild = await discordService.client.guilds.fetch(room.serverId);
+      const guild = await discordService.client.guilds.fetch(serverId);
 
       let member: GuildMember | null = null;
 

--- a/src/actions/readChannel.ts
+++ b/src/actions/readChannel.ts
@@ -164,7 +164,14 @@ export const readChannel: Action = {
       } else if (room?.serverId || room?.messageServerId) {
         // It's a channel name - search in the current server
         const serverId = room?.serverId ?? room?.messageServerId;
-        const guild = await discordService.client.guilds.fetch(serverId!);
+        if (!serverId) {
+          await callback({
+            text: "I couldn't determine which server to search in.",
+            source: 'discord',
+          });
+          return;
+        }
+        const guild = await discordService.client.guilds.fetch(serverId);
         const channels = await guild.channels.fetch();
 
         targetChannel =

--- a/src/actions/readChannel.ts
+++ b/src/actions/readChannel.ts
@@ -161,9 +161,10 @@ export const readChannel: Action = {
         targetChannel = (await discordService.client.channels.fetch(
           channelInfo.channelIdentifier
         )) as TextChannel;
-      } else if (room?.serverId) {
+      } else if (room?.serverId || room?.messageServerId) {
         // It's a channel name - search in the current server
-        const guild = await discordService.client.guilds.fetch(room.serverId);
+        const serverId = room?.serverId ?? room?.messageServerId;
+        const guild = await discordService.client.guilds.fetch(serverId!);
         const channels = await guild.channels.fetch();
 
         targetChannel =

--- a/src/actions/readChannel.ts
+++ b/src/actions/readChannel.ts
@@ -163,14 +163,8 @@ export const readChannel: Action = {
         )) as TextChannel;
       } else if (room?.serverId || room?.messageServerId) {
         // It's a channel name - search in the current server
-        const serverId = room?.serverId || room?.messageServerId;
-        if (!serverId) {
-          await callback({
-            text: "I couldn't determine which server to search in.",
-            source: 'discord',
-          });
-          return;
-        }
+        // serverId is guaranteed truthy since we're inside the || condition
+        const serverId = (room?.serverId || room?.messageServerId)!;
         const guild = await discordService.client.guilds.fetch(serverId);
         const channels = await guild.channels.fetch();
 

--- a/src/actions/readChannel.ts
+++ b/src/actions/readChannel.ts
@@ -163,7 +163,7 @@ export const readChannel: Action = {
         )) as TextChannel;
       } else if (room?.serverId || room?.messageServerId) {
         // It's a channel name - search in the current server
-        const serverId = room?.serverId ?? room?.messageServerId;
+        const serverId = room?.serverId || room?.messageServerId;
         if (!serverId) {
           await callback({
             text: "I couldn't determine which server to search in.",

--- a/src/actions/searchMessages.ts
+++ b/src/actions/searchMessages.ts
@@ -193,8 +193,9 @@ export const searchMessages: Action = {
         targetChannel = (await discordService.client.channels.fetch(
           searchParams.channelIdentifier
         )) as TextChannel;
-      } else if (room?.serverId) {
-        const guild = await discordService.client.guilds.fetch(room.serverId);
+      } else if (room?.serverId || room?.messageServerId) {
+        const serverId = room?.serverId ?? room?.messageServerId;
+        const guild = await discordService.client.guilds.fetch(serverId!);
         const channels = await guild.channels.fetch();
         targetChannel =
           (channels.find(

--- a/src/actions/searchMessages.ts
+++ b/src/actions/searchMessages.ts
@@ -195,7 +195,14 @@ export const searchMessages: Action = {
         )) as TextChannel;
       } else if (room?.serverId || room?.messageServerId) {
         const serverId = room?.serverId ?? room?.messageServerId;
-        const guild = await discordService.client.guilds.fetch(serverId!);
+        if (!serverId) {
+          await callback({
+            text: "I couldn't determine which server to search in.",
+            source: 'discord',
+          });
+          return;
+        }
+        const guild = await discordService.client.guilds.fetch(serverId);
         const channels = await guild.channels.fetch();
         targetChannel =
           (channels.find(

--- a/src/actions/searchMessages.ts
+++ b/src/actions/searchMessages.ts
@@ -194,7 +194,7 @@ export const searchMessages: Action = {
           searchParams.channelIdentifier
         )) as TextChannel;
       } else if (room?.serverId || room?.messageServerId) {
-        const serverId = room?.serverId ?? room?.messageServerId;
+        const serverId = room?.serverId || room?.messageServerId;
         if (!serverId) {
           await callback({
             text: "I couldn't determine which server to search in.",

--- a/src/actions/searchMessages.ts
+++ b/src/actions/searchMessages.ts
@@ -194,14 +194,8 @@ export const searchMessages: Action = {
           searchParams.channelIdentifier
         )) as TextChannel;
       } else if (room?.serverId || room?.messageServerId) {
-        const serverId = room?.serverId || room?.messageServerId;
-        if (!serverId) {
-          await callback({
-            text: "I couldn't determine which server to search in.",
-            source: 'discord',
-          });
-          return;
-        }
+        // serverId is guaranteed truthy since we're inside the || condition
+        const serverId = (room?.serverId || room?.messageServerId)!;
         const guild = await discordService.client.guilds.fetch(serverId);
         const channels = await guild.channels.fetch();
         targetChannel =

--- a/src/actions/serverInfo.ts
+++ b/src/actions/serverInfo.ts
@@ -13,12 +13,12 @@ import { type Guild } from 'discord.js';
 
 const formatServerInfo = (guild: Guild, detailed: boolean = false): string => {
   const createdAt = new Date(guild.createdAt).toLocaleDateString();
-  const memberCount = guild.memberCount;
-  const channelCount = guild.channels.cache.size;
-  const roleCount = guild.roles.cache.size;
-  const emojiCount = guild.emojis.cache.size;
+  const memberCount = guild.memberCount.toLocaleString();
+  const channelCount = guild.channels.cache.size.toLocaleString();
+  const roleCount = guild.roles.cache.size.toLocaleString();
+  const emojiCount = guild.emojis.cache.size.toLocaleString();
   const boostLevel = guild.premiumTier;
-  const boostCount = guild.premiumSubscriptionCount || 0;
+  const boostCount = (guild.premiumSubscriptionCount || 0).toLocaleString();
 
   const basicInfo = [
     `🏛️ **Server Information for ${guild.name}**`,
@@ -32,10 +32,11 @@ const formatServerInfo = (guild: Guild, detailed: boolean = false): string => {
   ];
 
   if (detailed) {
-    const textChannels = guild.channels.cache.filter((ch) => ch.isTextBased()).size;
-    const voiceChannels = guild.channels.cache.filter((ch) => ch.isVoiceBased()).size;
-    const categories = guild.channels.cache.filter((ch) => ch.type === 4).size; // CategoryChannel type
-    const activeThreads = guild.channels.cache.filter((ch) => ch.isThread() && !ch.archived).size;
+    const textChannels = guild.channels.cache.filter((ch) => ch.isTextBased()).size.toLocaleString();
+    const voiceChannels = guild.channels.cache.filter((ch) => ch.isVoiceBased()).size.toLocaleString();
+    const categories = guild.channels.cache.filter((ch) => ch.type === 4).size.toLocaleString(); // CategoryChannel type
+    const activeThreads = guild.channels.cache.filter((ch) => ch.isThread() && !ch.archived).size.toLocaleString();
+    const stickerCount = guild.stickers.cache.size.toLocaleString();
 
     const features =
       guild.features.length > 0
@@ -50,7 +51,7 @@ const formatServerInfo = (guild: Guild, detailed: boolean = false): string => {
       `**Categories:** ${categories}`,
       `**Active Threads:** ${activeThreads}`,
       `**Custom Emojis:** ${emojiCount}`,
-      `**Stickers:** ${guild.stickers.cache.size}`,
+      `**Stickers:** ${stickerCount}`,
       '',
       `🎯 **Server Features**`,
       `**Verification Level:** ${guild.verificationLevel}`,
@@ -108,7 +109,8 @@ export const serverInfo: Action = {
 
     try {
       const room = state.data?.room || (await runtime.getRoom(message.roomId));
-      if (!room?.serverId) {
+      const serverId = room?.serverId ?? room?.messageServerId;
+      if (!serverId) {
         await callback({
           text: "I couldn't determine the current server.",
           source: 'discord',
@@ -116,7 +118,7 @@ export const serverInfo: Action = {
         return;
       }
 
-      const guild = await discordService.client.guilds.fetch(room.serverId);
+      const guild = await discordService.client.guilds.fetch(serverId);
 
       // Check if the request is for detailed info
       const messageText = message.content.text?.toLowerCase() || '';

--- a/src/banner.ts
+++ b/src/banner.ts
@@ -5,7 +5,7 @@
  */
 
 import type { IAgentRuntime } from '@elizaos/core';
-import type { DiscordPermissionValues } from './permissions';
+import { getPermissionValues, type DiscordPermissionValues } from './permissions';
 
 const ANSI = {
   reset: '\x1b[0m',
@@ -215,23 +215,20 @@ export function printDiscordBanner(runtime: IAgentRuntime): void {
   const listenChannels = runtime.getSetting('DISCORD_LISTEN_CHANNEL_IDS');
   const voiceChannelId = runtime.getSetting('DISCORD_VOICE_CHANNEL_ID');
 
-  // Import permission values dynamically to avoid circular dependency
-  import('./permissions').then(({ getPermissionValues }) => {
-    printBanner({
-      pluginName: 'plugin-discord',
-      description: 'Discord bot integration for servers and channels',
-      applicationId: applicationId || undefined,
-      discordPermissions: applicationId ? getPermissionValues() : undefined,
-      settings: [
-        { name: 'DISCORD_API_TOKEN', value: apiToken, sensitive: true, required: true },
-        { name: 'DISCORD_APPLICATION_ID', value: applicationId },
-        { name: 'DISCORD_VOICE_CHANNEL_ID', value: voiceChannelId },
-        { name: 'DISCORD_LISTEN_CHANNEL_IDS', value: listenChannels },
-        { name: 'DISCORD_SHOULD_IGNORE_BOT_MESSAGES', value: ignoreBots, defaultValue: 'false' },
-        { name: 'DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES', value: ignoreDMs, defaultValue: 'false' },
-        { name: 'DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS', value: onlyMentions, defaultValue: 'false' },
-      ],
-      runtime,
-    });
+  printBanner({
+    pluginName: 'plugin-discord',
+    description: 'Discord bot integration for servers and channels',
+    applicationId: applicationId || undefined,
+    discordPermissions: applicationId ? getPermissionValues() : undefined,
+    settings: [
+      { name: 'DISCORD_API_TOKEN', value: apiToken, sensitive: true, required: true },
+      { name: 'DISCORD_APPLICATION_ID', value: applicationId },
+      { name: 'DISCORD_VOICE_CHANNEL_ID', value: voiceChannelId },
+      { name: 'DISCORD_LISTEN_CHANNEL_IDS', value: listenChannels },
+      { name: 'DISCORD_SHOULD_IGNORE_BOT_MESSAGES', value: ignoreBots, defaultValue: 'false' },
+      { name: 'DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES', value: ignoreDMs, defaultValue: 'false' },
+      { name: 'DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS', value: onlyMentions, defaultValue: 'false' },
+    ],
+    runtime,
   });
 }

--- a/src/banner.ts
+++ b/src/banner.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IAgentRuntime } from '@elizaos/core';
+import type { DiscordPermissionValues } from './permissions';
 
 const ANSI = {
   reset: '\x1b[0m',
@@ -26,18 +27,6 @@ export interface PluginSetting {
   defaultValue?: unknown;
   sensitive?: boolean;
   required?: boolean;
-}
-
-/**
- * Discord permission values for all tiers (3x2 matrix)
- */
-export interface DiscordPermissionValues {
-  basic: number;
-  basicVoice: number;
-  moderator: number;
-  moderatorVoice: number;
-  admin: number;
-  adminVoice: number;
 }
 
 export interface BannerOptions {

--- a/src/banner.ts
+++ b/src/banner.ts
@@ -203,7 +203,7 @@ export function printDiscordBanner(runtime: IAgentRuntime): void {
     printBanner({
       pluginName: 'plugin-discord',
       description: 'Discord bot integration for servers and channels',
-      applicationId: applicationId as string || undefined,
+      applicationId: applicationId || undefined,
       discordPermissions: applicationId ? getPermissionValues() : undefined,
       settings: [
         { name: 'DISCORD_API_TOKEN', value: apiToken, sensitive: true, required: true },

--- a/src/banner.ts
+++ b/src/banner.ts
@@ -1,59 +1,220 @@
 /**
  * Discord Plugin Settings Banner
  * Beautiful ANSI art display for configuration on startup
+ * Includes tiered permission system for invite URLs
  */
 
 import type { IAgentRuntime } from '@elizaos/core';
 
-const colors = {
-    reset: '\x1b[0m',
-    bright: '\x1b[1m',
-    dim: '\x1b[2m',
-    yellow: '\x1b[33m',
-    cyan: '\x1b[36m',
-    white: '\x1b[37m',
-    brightCyan: '\x1b[96m',
-    brightBlue: '\x1b[94m',
-    brightWhite: '\x1b[97m',
-    green: '\x1b[32m',
+const ANSI = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  blue: '\x1b[34m',
+  brightRed: '\x1b[91m',
+  brightGreen: '\x1b[92m',
+  brightYellow: '\x1b[93m',
+  brightBlue: '\x1b[94m',
+  brightMagenta: '\x1b[95m',
+  brightCyan: '\x1b[96m',
+  brightWhite: '\x1b[97m',
 };
 
-export function printDiscordBanner(runtime: IAgentRuntime): void {
-    // Get settings
-    const apiToken = runtime.getSetting('DISCORD_API_TOKEN');
-    const ignoreBots = runtime.getSetting('DISCORD_SHOULD_IGNORE_BOT_MESSAGES');
-    const ignoreDMs = runtime.getSetting('DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES');
-    const onlyMentions = runtime.getSetting('DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS');
-    const listenChannels = runtime.getSetting('DISCORD_LISTEN_CHANNEL_IDS');
-    const voiceChannelId = runtime.getSetting('DISCORD_VOICE_CHANNEL_ID');
-
-    // Check defaults
-    const ignoreBotsDefault = ignoreBots === undefined;
-    const ignoreDMsDefault = ignoreDMs === undefined;
-    const onlyMentionsDefault = onlyMentions === undefined;
-
-    const banner = `
-${colors.brightBlue}================================================================================
-${colors.brightBlue}   ____  ___  ____   ____ ____  ____  ____     ____  _     _   _  ____ ___ _   _ 
-${colors.brightCyan}  |  _ \\|_ _|/ ___| / ___/ _ \\|  _ \\|  _ \\   |  _ \\| |   | | | |/ ___|_ _| \\ | |
-${colors.brightCyan}  | | | || | \\___ \\| |  | | | | |_) | | | |  | |_) | |   | | | | |  _ | ||  \\| |
-${colors.brightBlue}  | |_| || |  ___) | |__| |_| |  _ <| |_| |  |  __/| |___| |_| | |_| || || |\\  |
-${colors.brightBlue}  |____/|___||____/ \\____\\___/|_| \\_\\____/   |_|   |_____|\\___/ \\____|___|_| \\_|
-${colors.brightBlue}================================================================================${colors.reset}
-
-${colors.cyan}Configuration:${colors.reset}
-  ${colors.yellow}DISCORD_API_TOKEN${colors.reset}                    = ${apiToken ? colors.green + '***set***' : colors.dim + 'not set'} ${apiToken ? colors.green + '(configured)' : colors.dim + '(required)'}${colors.reset}
-  ${colors.yellow}DISCORD_SHOULD_IGNORE_BOT_MESSAGES${colors.reset}   = ${colors.white}${ignoreBots || 'false'}${ignoreBotsDefault ? colors.dim + '*' : ''}${colors.reset} ${ignoreBotsDefault ? colors.dim + '(default)' : colors.green + '(set)'}${colors.reset}
-  ${colors.yellow}DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES${colors.reset} = ${colors.white}${ignoreDMs || 'false'}${ignoreDMsDefault ? colors.dim + '*' : ''}${colors.reset} ${ignoreDMsDefault ? colors.dim + '(default)' : colors.green + '(set)'}${colors.reset}
-  ${colors.yellow}DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS${colors.reset} = ${colors.white}${onlyMentions || 'false'}${onlyMentionsDefault ? colors.dim + '*' : ''}${colors.reset} ${onlyMentionsDefault ? colors.dim + '(default)' : colors.green + '(set)'}${colors.reset}
-  ${colors.yellow}DISCORD_LISTEN_CHANNEL_IDS${colors.reset}           = ${listenChannels ? colors.white + 'configured' + colors.reset + ' ' + colors.green + '(set)' : colors.dim + 'not set (optional)'}${colors.reset}
-  ${colors.yellow}DISCORD_VOICE_CHANNEL_ID${colors.reset}             = ${voiceChannelId ? colors.white + 'configured' + colors.reset + ' ' + colors.green + '(set)' : colors.dim + 'not set (optional)'}${colors.reset}
-
-${colors.dim}* = default value | Configure via .env file${colors.reset}
-${colors.brightBlue}================================================================================${colors.reset}
-`;
-
-    // Use logger.info with source context for proper log formatting
-    runtime.logger.info({ src: 'plugin:discord', agentId: runtime.agentId }, `\n${banner}\n`);
+export interface PluginSetting {
+  name: string;
+  value: unknown;
+  defaultValue?: unknown;
+  sensitive?: boolean;
+  required?: boolean;
 }
 
+/**
+ * Discord permission values for all tiers (3x2 matrix)
+ */
+export interface DiscordPermissionValues {
+  basic: number;
+  basicVoice: number;
+  moderator: number;
+  moderatorVoice: number;
+  admin: number;
+  adminVoice: number;
+}
+
+export interface BannerOptions {
+  pluginName: string;
+  description?: string;
+  settings: PluginSetting[];
+  runtime: IAgentRuntime;
+  /** Discord Application ID for generating invite URLs */
+  applicationId?: string;
+  /** Permission values for the 3x2 tier matrix */
+  discordPermissions?: DiscordPermissionValues;
+  /** @deprecated Use applicationId + discordPermissions instead */
+  discordInviteLink?: string;
+}
+
+function mask(v: string): string {
+  if (!v || v.length < 8) return '••••••••';
+  return `${v.slice(0, 4)}${'•'.repeat(Math.min(12, v.length - 8))}${v.slice(-4)}`;
+}
+
+function fmtVal(value: unknown, sensitive: boolean, maxLen: number): string {
+  let s: string;
+  if (value === undefined || value === null || value === '') {
+    s = '(not set)';
+  } else if (sensitive) {
+    s = mask(String(value));
+  } else {
+    s = String(value);
+  }
+  if (s.length > maxLen) s = s.slice(0, maxLen - 3) + '...';
+  return s;
+}
+
+function isDef(v: unknown, d: unknown): boolean {
+  if (v === undefined || v === null || v === '') return true;
+  return d !== undefined && v === d;
+}
+
+function pad(s: string, n: number): string {
+  const len = s.replace(/\x1b\[[0-9;]*m/g, '').length;
+  if (len >= n) return s;
+  return s + ' '.repeat(n - len);
+}
+
+function line(content: string): string {
+  const len = content.replace(/\x1b\[[0-9;]*m/g, '').length;
+  if (len > 78) return content.slice(0, 78);
+  return content + ' '.repeat(78 - len);
+}
+
+/**
+ * Print the Discord plugin settings banner with tiered invite URLs
+ */
+export function printBanner(options: BannerOptions): void {
+  const { settings, runtime } = options;
+  const R = ANSI.reset,
+    D = ANSI.dim,
+    B = ANSI.bold;
+  const c1 = ANSI.brightBlue,
+    c2 = ANSI.brightCyan,
+    c3 = ANSI.brightMagenta;
+
+  const top = `${c1}╔${'═'.repeat(78)}╗${R}`;
+  const mid = `${c1}╠${'═'.repeat(78)}╣${R}`;
+  const bot = `${c1}╚${'═'.repeat(78)}╝${R}`;
+  const row = (s: string) => `${c1}║${R}${line(s)}${c1}║${R}`;
+
+  const lines: string[] = [''];
+  lines.push(top);
+  lines.push(row(` ${B}Character: ${runtime.character.name}${R}`));
+  lines.push(mid);
+  lines.push(row(`${c2}     ██████╗ ██╗███████╗ ██████╗ ██████╗ ██████╗ ██████╗     ${c3}◖ ◗${R}`));
+  lines.push(row(`${c2}     ██╔══██╗██║██╔════╝██╔════╝██╔═══██╗██╔══██╗██╔══██╗   ${c3}◖===◗${R}`));
+  lines.push(row(`${c2}     ██║  ██║██║███████╗██║     ██║   ██║██████╔╝██║  ██║    ${c3}╰─╯${R}`));
+  lines.push(row(`${c2}     ██████╔╝██║╚════██║╚██████╗╚██████╔╝██║  ██║██████╔╝   ${c3}(◠◠)${R}`));
+  lines.push(row(`${c2}     ╚═════╝ ╚═╝╚══════╝ ╚═════╝ ╚═════╝ ╚═╝  ╚═╝╚═════╝     ${c3}‿‿${R}`));
+  lines.push(row(`${D}            Bot Integration  •  Servers  •  Channels  •  Voice${R}`));
+  lines.push(mid);
+
+  const NW = 34,
+    VW = 26,
+    SW = 8;
+  lines.push(row(` ${B}${pad('ENV VARIABLE', NW)} ${pad('VALUE', VW)} ${pad('STATUS', SW)}${R}`));
+  lines.push(row(` ${D}${'-'.repeat(NW)} ${'-'.repeat(VW)} ${'-'.repeat(SW)}${R}`));
+
+  for (const s of settings) {
+    const def = isDef(s.value, s.defaultValue);
+    const set = s.value !== undefined && s.value !== null && s.value !== '';
+
+    let ico: string, st: string;
+    if (!set && s.required) {
+      ico = `${ANSI.brightRed}◆${R}`;
+      st = `${ANSI.brightRed}REQUIRED${R}`;
+    } else if (!set) {
+      ico = `${D}○${R}`;
+      st = `${D}default${R}`;
+    } else if (def) {
+      ico = `${ANSI.brightBlue}●${R}`;
+      st = `${ANSI.brightBlue}default${R}`;
+    } else {
+      ico = `${ANSI.brightGreen}✓${R}`;
+      st = `${ANSI.brightGreen}custom${R}`;
+    }
+
+    const name = pad(s.name, NW - 2);
+    const val = pad(fmtVal(s.value ?? s.defaultValue, s.sensitive ?? false, VW), VW);
+    const status = pad(st, SW);
+    lines.push(row(` ${ico} ${c2}${name}${R} ${val} ${status}`));
+  }
+
+  lines.push(mid);
+  lines.push(
+    row(
+      ` ${D}${ANSI.brightGreen}✓${D} custom  ${ANSI.brightBlue}●${D} default  ○ unset  ${ANSI.brightRed}◆${D} required      → Set in .env${R}`
+    )
+  );
+  lines.push(bot);
+
+  // Add Discord invite links organized by voice capability
+  if (options.applicationId && options.discordPermissions) {
+    const p = options.discordPermissions;
+    const baseUrl = `https://discord.com/api/oauth2/authorize?client_id=${options.applicationId}&scope=bot%20applications.commands&permissions=`;
+
+    lines.push('');
+    lines.push(`${B}${ANSI.brightCyan}🔗 Discord Bot Invite${R}`);
+    lines.push('');
+    lines.push(`   ${B}🎙️  With Voice:${R}`);
+    lines.push(`   ${ANSI.brightGreen}● Basic${R}      ${baseUrl}${p.basicVoice}`);
+    lines.push(`   ${ANSI.brightYellow}● Moderator${R}  ${baseUrl}${p.moderatorVoice}`);
+    lines.push(`   ${ANSI.brightRed}● Admin${R}      ${baseUrl}${p.adminVoice}`);
+    lines.push('');
+    lines.push(`   ${B}💬 Without Voice:${R}`);
+    lines.push(`   ${ANSI.brightCyan}○ Basic${R}      ${baseUrl}${p.basic}`);
+    lines.push(`   ${ANSI.brightMagenta}○ Moderator${R}  ${baseUrl}${p.moderator}`);
+    lines.push(`   ${ANSI.brightBlue}○ Admin${R}      ${baseUrl}${p.admin}`);
+  } else if (options.discordInviteLink) {
+    // Backwards compatibility
+    lines.push('');
+    lines.push(`${B}${ANSI.brightCyan}🔗 Discord Bot Invite:${R} ${options.discordInviteLink}`);
+  }
+
+  lines.push('');
+
+  runtime.logger.info(lines.join('\n'));
+}
+
+/**
+ * Simple banner for backwards compatibility
+ * @deprecated Use printBanner with BannerOptions instead
+ */
+export function printDiscordBanner(runtime: IAgentRuntime): void {
+  // Get settings
+  const apiToken = runtime.getSetting('DISCORD_API_TOKEN');
+  const applicationId = runtime.getSetting('DISCORD_APPLICATION_ID');
+  const ignoreBots = runtime.getSetting('DISCORD_SHOULD_IGNORE_BOT_MESSAGES');
+  const ignoreDMs = runtime.getSetting('DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES');
+  const onlyMentions = runtime.getSetting('DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS');
+  const listenChannels = runtime.getSetting('DISCORD_LISTEN_CHANNEL_IDS');
+  const voiceChannelId = runtime.getSetting('DISCORD_VOICE_CHANNEL_ID');
+
+  // Import permission values dynamically to avoid circular dependency
+  import('./permissions').then(({ getPermissionValues }) => {
+    printBanner({
+      pluginName: 'plugin-discord',
+      description: 'Discord bot integration for servers and channels',
+      applicationId: applicationId as string || undefined,
+      discordPermissions: applicationId ? getPermissionValues() : undefined,
+      settings: [
+        { name: 'DISCORD_API_TOKEN', value: apiToken, sensitive: true, required: true },
+        { name: 'DISCORD_APPLICATION_ID', value: applicationId },
+        { name: 'DISCORD_VOICE_CHANNEL_ID', value: voiceChannelId },
+        { name: 'DISCORD_LISTEN_CHANNEL_IDS', value: listenChannels },
+        { name: 'DISCORD_SHOULD_IGNORE_BOT_MESSAGES', value: ignoreBots, defaultValue: 'false' },
+        { name: 'DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES', value: ignoreDMs, defaultValue: 'false' },
+        { name: 'DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS', value: onlyMentions, defaultValue: 'false' },
+      ],
+      runtime,
+    });
+  });
+}

--- a/src/banner.ts
+++ b/src/banner.ts
@@ -72,9 +72,37 @@ function pad(s: string, n: number): string {
 }
 
 function line(content: string): string {
-  const len = content.replace(/\x1b\[[0-9;]*m/g, '').length;
-  if (len > 78) return content.slice(0, 78);
-  return content + ' '.repeat(78 - len);
+  const ansiPattern = /\x1b\[[0-9;]*m/g;
+  const len = content.replace(ansiPattern, '').length;
+
+  if (len <= 78) {
+    return content + ' '.repeat(78 - len);
+  }
+
+  // Truncate based on visible character count, not raw string position
+  // This avoids cutting in the middle of ANSI escape sequences
+  let visibleCount = 0;
+  let result = '';
+  let i = 0;
+
+  while (i < content.length && visibleCount < 78) {
+    const remaining = content.slice(i);
+    const match = remaining.match(/^\x1b\[[0-9;]*m/);
+
+    if (match) {
+      // Include ANSI sequence without counting toward visible length
+      result += match[0];
+      i += match[0].length;
+    } else {
+      // Regular visible character
+      result += content[i];
+      visibleCount++;
+      i++;
+    }
+  }
+
+  // Reset any unclosed ANSI sequences after truncation
+  return result + ANSI.reset;
 }
 
 /**

--- a/src/banner.ts
+++ b/src/banner.ts
@@ -54,7 +54,7 @@ export interface BannerOptions {
 }
 
 function mask(v: string): string {
-  if (!v || v.length < 8) return '••••••••';
+  if (!v || v.length <= 8) return '••••••••';
   return `${v.slice(0, 4)}${'•'.repeat(Math.min(12, v.length - 8))}${v.slice(-4)}`;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ import { channelStateProvider } from './providers/channelState';
 import { voiceStateProvider } from './providers/voiceState';
 import { DiscordService } from './service';
 import { DiscordTestSuite } from './tests';
-import { printDiscordBanner } from './banner';
+import { printBanner } from './banner';
+import { getPermissionValues } from './permissions';
 
 const discordPlugin: Plugin = {
   name: 'discord',
@@ -47,10 +48,66 @@ const discordPlugin: Plugin = {
   providers: [channelStateProvider, voiceStateProvider],
   tests: [new DiscordTestSuite()],
   init: async (_config: Record<string, string>, runtime: IAgentRuntime) => {
-    // Print beautiful settings banner
-    printDiscordBanner(runtime);
-    
+    // Gather ALL Discord settings
     const token = runtime.getSetting('DISCORD_API_TOKEN') as string;
+    const applicationId = runtime.getSetting('DISCORD_APPLICATION_ID') as string;
+    const voiceChannelId = runtime.getSetting('DISCORD_VOICE_CHANNEL_ID') as string;
+    const channelIds = runtime.getSetting('CHANNEL_IDS') as string;
+    const listenChannelIds = runtime.getSetting('DISCORD_LISTEN_CHANNEL_IDS') as string;
+    const ignoreBotMessages = runtime.getSetting('DISCORD_SHOULD_IGNORE_BOT_MESSAGES') as string;
+    const ignoreDirectMessages = runtime.getSetting('DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES') as string;
+    const respondOnlyToMentions = runtime.getSetting('DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS') as string;
+
+    // Print beautiful settings banner with ALL settings
+    // Includes tiered permission matrix for Discord invite URLs:
+    // - Basic / Moderator / Admin (role levels)
+    // - With or without voice permissions
+    printBanner({
+      pluginName: 'plugin-discord',
+      description: 'Discord bot integration for servers and channels',
+      applicationId: applicationId || undefined,
+      discordPermissions: applicationId ? getPermissionValues() : undefined,
+      settings: [
+        {
+          name: 'DISCORD_API_TOKEN',
+          value: token,
+          sensitive: true,
+          required: true,
+        },
+        {
+          name: 'DISCORD_APPLICATION_ID',
+          value: applicationId,
+        },
+        {
+          name: 'DISCORD_VOICE_CHANNEL_ID',
+          value: voiceChannelId,
+        },
+        {
+          name: 'CHANNEL_IDS',
+          value: channelIds,
+        },
+        {
+          name: 'DISCORD_LISTEN_CHANNEL_IDS',
+          value: listenChannelIds,
+        },
+        {
+          name: 'DISCORD_SHOULD_IGNORE_BOT_MESSAGES',
+          value: ignoreBotMessages,
+          defaultValue: 'false',
+        },
+        {
+          name: 'DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES',
+          value: ignoreDirectMessages,
+          defaultValue: 'false',
+        },
+        {
+          name: 'DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS',
+          value: respondOnlyToMentions,
+          defaultValue: 'false',
+        },
+      ],
+      runtime,
+    });
 
     if (!token || token.trim() === '') {
       logger.warn(
@@ -90,3 +147,13 @@ export {
   isElevatedRole,
   hasElevatedPermissions,
 } from './permissionEvents';
+
+// Export permission tier system for invite URL generation
+export {
+  DiscordPermissionTiers,
+  generateInviteUrl,
+  generateAllInviteUrls,
+  getPermissionValues,
+  type DiscordPermissionTier,
+  type DiscordPermissionValues,
+} from './permissions';

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -203,6 +203,18 @@ export class MessageManager {
                   : 'none',
           },
         },
+        extraMetadata: {
+          // Reply attribution for cross-agent filtering
+          // WHY: When user replies to another bot's message, we need to know
+          // so other agents can ignore it (only the replied-to agent should respond)
+          replyToAuthor: message.mentions.repliedUser
+            ? {
+              id: message.mentions.repliedUser.id,
+              username: message.mentions.repliedUser.username,
+              isBot: message.mentions.repliedUser.bot,
+            }
+            : undefined,
+        },
       });
 
       if (!newMessage) {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,0 +1,272 @@
+/**
+ * Discord bot permission tiers for different use cases.
+ *
+ * Permissions are organized in a 3x2 matrix:
+ * - Role axis: Basic / Moderator / Admin
+ * - Voice axis: Without voice / With voice
+ *
+ * Discord permissions are bit flags. We combine them using bitwise OR.
+ * @see https://discord.com/developers/docs/topics/permissions
+ */
+
+// Individual permission bit values (from Discord.js PermissionsBitField.Flags)
+const Permissions = {
+  // Reactions
+  AddReactions: 1n << 6n, // 64
+
+  // Voice (low bits)
+  PrioritySpeaker: 1n << 8n, // 256
+  Stream: 1n << 9n, // 512
+
+  // General
+  ViewChannel: 1n << 10n, // 1024 - Required to see channels
+
+  // Text
+  SendMessages: 1n << 11n, // 2048
+  SendTTSMessages: 1n << 12n, // 4096
+  ManageMessages: 1n << 13n, // 8192 - Pin/unpin, delete others' messages
+  EmbedLinks: 1n << 14n, // 16384
+  AttachFiles: 1n << 15n, // 32768
+  ReadMessageHistory: 1n << 16n, // 65536
+  MentionEveryone: 1n << 17n, // 131072
+  UseExternalEmojis: 1n << 18n, // 262144
+
+  // Voice
+  Connect: 1n << 20n, // 1048576
+  Speak: 1n << 21n, // 2097152
+  MuteMembers: 1n << 22n, // 4194304
+  DeafenMembers: 1n << 23n, // 8388608
+  MoveMembers: 1n << 24n, // 16777216
+  UseVAD: 1n << 25n, // 33554432 - Voice Activity Detection
+
+  // Member management
+  KickMembers: 1n << 1n, // 2
+  BanMembers: 1n << 2n, // 4
+  ChangeNickname: 1n << 26n, // 67108864
+  ManageNicknames: 1n << 27n, // 134217728
+
+  // Server management
+  ManageChannels: 1n << 4n, // 16
+  ManageRoles: 1n << 28n, // 268435456
+  ManageWebhooks: 1n << 29n, // 536870912
+  ManageGuildExpressions: 1n << 30n, // 1073741824
+
+  // Advanced
+  UseApplicationCommands: 1n << 31n, // 2147483648 - Slash commands
+  ManageThreads: 1n << 34n, // 17179869184
+  CreatePublicThreads: 1n << 35n, // 34359738368
+  CreatePrivateThreads: 1n << 36n, // 68719476736
+  UseExternalStickers: 1n << 37n, // 137438953472
+  SendMessagesInThreads: 1n << 38n, // 274877906944
+  UseEmbeddedActivities: 1n << 39n, // 549755813888
+  ModerateMembers: 1n << 40n, // 1099511627776 - Timeout members
+  SendVoiceMessages: 1n << 46n, // 70368744177664
+  SendPolls: 1n << 47n, // 140737488355328
+} as const;
+
+// ============================================================================
+// BASE PERMISSION SETS
+// ============================================================================
+
+/**
+ * Basic text permissions - minimal footprint for text interaction
+ */
+const TEXT_BASIC =
+  Permissions.ViewChannel |
+  Permissions.AddReactions |
+  Permissions.SendMessages |
+  Permissions.EmbedLinks |
+  Permissions.AttachFiles |
+  Permissions.UseExternalEmojis |
+  Permissions.ReadMessageHistory |
+  Permissions.SendMessagesInThreads |
+  Permissions.UseApplicationCommands;
+
+/**
+ * Moderator text permissions - adds moderation capabilities
+ */
+const TEXT_MODERATOR =
+  TEXT_BASIC |
+  Permissions.ManageMessages |
+  Permissions.MentionEveryone |
+  Permissions.CreatePublicThreads |
+  Permissions.CreatePrivateThreads |
+  Permissions.ManageThreads |
+  Permissions.UseExternalStickers |
+  Permissions.SendPolls |
+  Permissions.ModerateMembers; // Timeout members
+
+/**
+ * Admin text permissions - adds member/server management
+ */
+const TEXT_ADMIN =
+  TEXT_MODERATOR |
+  Permissions.KickMembers |
+  Permissions.BanMembers |
+  Permissions.ManageNicknames |
+  Permissions.ManageChannels |
+  Permissions.ManageRoles |
+  Permissions.ManageWebhooks |
+  Permissions.ManageGuildExpressions;
+
+/**
+ * Voice permissions add-on
+ */
+const VOICE_ADDON =
+  Permissions.Connect |
+  Permissions.Speak |
+  Permissions.UseVAD |
+  Permissions.PrioritySpeaker |
+  Permissions.Stream |
+  Permissions.SendVoiceMessages;
+
+/**
+ * Voice moderation add-on (for admin tier)
+ */
+const VOICE_ADMIN_ADDON =
+  VOICE_ADDON |
+  Permissions.MuteMembers |
+  Permissions.DeafenMembers |
+  Permissions.MoveMembers;
+
+// ============================================================================
+// PERMISSION TIERS (3x2 Matrix)
+// ============================================================================
+
+/**
+ * Basic - Text only, no moderation, no voice
+ * Good for: Simple chatbots, read-only bots, basic assistants
+ */
+export const PERMISSIONS_BASIC = TEXT_BASIC;
+
+/**
+ * Basic + Voice - Text with voice, no moderation
+ * Good for: Voice assistants, music bots without mod powers
+ */
+export const PERMISSIONS_BASIC_VOICE = TEXT_BASIC | VOICE_ADDON;
+
+/**
+ * Moderator - Text with moderation, no voice
+ * Good for: Community bots, moderation assistants, engagement bots
+ */
+export const PERMISSIONS_MODERATOR = TEXT_MODERATOR;
+
+/**
+ * Moderator + Voice - Text + moderation + voice
+ * Good for: Full-featured community bots with voice
+ */
+export const PERMISSIONS_MODERATOR_VOICE = TEXT_MODERATOR | VOICE_ADDON;
+
+/**
+ * Admin - Text with full server management, no voice
+ * Good for: Server management bots, admin tools
+ */
+export const PERMISSIONS_ADMIN = TEXT_ADMIN;
+
+/**
+ * Admin + Voice - Full permissions (text + admin + voice + voice moderation)
+ * Good for: Complete server integration, owner-level bots
+ */
+export const PERMISSIONS_ADMIN_VOICE = TEXT_ADMIN | VOICE_ADMIN_ADDON;
+
+// ============================================================================
+// EXPORTS
+// ============================================================================
+
+/**
+ * Permission tiers as numbers for URL generation.
+ *
+ * Matrix (3x2):
+ * |            | No Voice         | With Voice            |
+ * |------------|------------------|-----------------------|
+ * | Basic      | BASIC            | BASIC_VOICE           |
+ * | Moderator  | MODERATOR        | MODERATOR_VOICE       |
+ * | Admin      | ADMIN            | ADMIN_VOICE           |
+ */
+export const DiscordPermissionTiers = {
+  /** Basic text-only permissions (no moderation, no voice) */
+  BASIC: Number(PERMISSIONS_BASIC),
+  /** Basic + voice permissions (no moderation) */
+  BASIC_VOICE: Number(PERMISSIONS_BASIC_VOICE),
+  /** Moderator permissions (text + moderation, no voice) */
+  MODERATOR: Number(PERMISSIONS_MODERATOR),
+  /** Moderator + voice permissions */
+  MODERATOR_VOICE: Number(PERMISSIONS_MODERATOR_VOICE),
+  /** Admin permissions (text + moderation + server management, no voice) */
+  ADMIN: Number(PERMISSIONS_ADMIN),
+  /** Admin + voice permissions (full permissions) */
+  ADMIN_VOICE: Number(PERMISSIONS_ADMIN_VOICE),
+
+  // Alias for backwards compatibility
+  /** @deprecated Use MODERATOR_VOICE instead */
+  FULL: Number(PERMISSIONS_MODERATOR_VOICE),
+} as const;
+
+// Type for tier names
+export type DiscordPermissionTier = keyof typeof DiscordPermissionTiers;
+
+/**
+ * Generate a Discord OAuth2 invite URL for the bot.
+ */
+export function generateInviteUrl(
+  applicationId: string,
+  tier: DiscordPermissionTier = 'MODERATOR_VOICE'
+): string {
+  const permissions = DiscordPermissionTiers[tier];
+  return `https://discord.com/api/oauth2/authorize?client_id=${applicationId}&permissions=${permissions}&scope=bot%20applications.commands`;
+}
+
+/**
+ * Permission values for all tiers (for compact display).
+ */
+export interface DiscordPermissionValues {
+  basic: number;
+  basicVoice: number;
+  moderator: number;
+  moderatorVoice: number;
+  admin: number;
+  adminVoice: number;
+}
+
+/**
+ * Get all permission values for the 3x2 tier matrix.
+ */
+export function getPermissionValues(): DiscordPermissionValues {
+  return {
+    basic: DiscordPermissionTiers.BASIC,
+    basicVoice: DiscordPermissionTiers.BASIC_VOICE,
+    moderator: DiscordPermissionTiers.MODERATOR,
+    moderatorVoice: DiscordPermissionTiers.MODERATOR_VOICE,
+    admin: DiscordPermissionTiers.ADMIN,
+    adminVoice: DiscordPermissionTiers.ADMIN_VOICE,
+  };
+}
+
+/**
+ * Invite URLs organized by tier for display.
+ */
+export interface DiscordInviteUrls {
+  basic: string;
+  basicVoice: string;
+  moderator: string;
+  moderatorVoice: string;
+  admin: string;
+  adminVoice: string;
+}
+
+/**
+ * Generate all tier invite URLs for display.
+ */
+export function generateAllInviteUrls(applicationId: string): DiscordInviteUrls {
+  return {
+    basic: generateInviteUrl(applicationId, 'BASIC'),
+    basicVoice: generateInviteUrl(applicationId, 'BASIC_VOICE'),
+    moderator: generateInviteUrl(applicationId, 'MODERATOR'),
+    moderatorVoice: generateInviteUrl(applicationId, 'MODERATOR_VOICE'),
+    admin: generateInviteUrl(applicationId, 'ADMIN'),
+    adminVoice: generateInviteUrl(applicationId, 'ADMIN_VOICE'),
+  };
+}
+
+// For backwards compatibility
+export const REQUIRED_PERMISSIONS = PERMISSIONS_MODERATOR_VOICE;

--- a/src/providers/channelState.ts
+++ b/src/providers/channelState.ts
@@ -38,6 +38,7 @@ export const channelStateProvider: Provider = {
     let channelType = '';
     let serverName = '';
     const channelId = room.channelId ?? '';
+    const serverId = room.serverId ?? (room as any).messageServerId;
 
     if (room.type === ChannelType.DM) {
       channelType = 'DM';

--- a/src/providers/channelState.ts
+++ b/src/providers/channelState.ts
@@ -38,7 +38,6 @@ export const channelStateProvider: Provider = {
     let channelType = '';
     let serverName = '';
     const channelId = room.channelId ?? '';
-    const serverId = room.serverId ?? (room as any).messageServerId;
 
     if (room.type === ChannelType.DM) {
       channelType = 'DM';

--- a/src/providers/voiceState.ts
+++ b/src/providers/voiceState.ts
@@ -38,6 +38,7 @@ export const voiceStateProvider: Provider = {
     }
 
     const channelId = room.channelId;
+    const serverId = room.serverId ?? (room as any).messageServerId;
     const agentName = state?.agentName || 'The agent';
 
     if (!channelId) {
@@ -49,6 +50,7 @@ export const voiceStateProvider: Provider = {
         },
         values: {
           isInVoiceChannel: 'false',
+          roomType: room.type,
         },
         text: `${agentName} is not currently in a voice channel`,
       };

--- a/src/providers/voiceState.ts
+++ b/src/providers/voiceState.ts
@@ -38,7 +38,6 @@ export const voiceStateProvider: Provider = {
     }
 
     const channelId = room.channelId;
-    const serverId = room.serverId ?? (room as any).messageServerId;
     const agentName = state?.agentName || 'The agent';
 
     if (!channelId) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -78,8 +78,10 @@ import {
 import { DISCORD_SERVICE_NAME } from './constants';
 import { getDiscordSettings } from './environment';
 import { MessageManager } from './messages';
+
 import { DiscordEventTypes, type IDiscordService, type DiscordSettings, type DiscordSlashCommand, type ChannelHistoryOptions, type ChannelHistoryResult, type ChannelSpiderState } from './types';
 import { getAttachmentFileName, splitMessage, MAX_MESSAGE_LENGTH } from './utils';
+import { DiscordPermissionTiers, generateInviteUrl } from './permissions';
 import { VoiceManager } from './voice';
 import {
   diffOverwrites,
@@ -1781,7 +1783,7 @@ export class DiscordService extends Service implements IDiscordService {
 
     // Strategy based on guild size
     if (guild.memberCount > 1000) {
-      this.runtime.logger.debug({ src: 'plugin:discord', agentId: this.runtime.agentId, guildId: guild.id, memberCount: guild.memberCount }, 'Using optimized user sync for large guild');
+      this.runtime.logger.debug({ src: 'plugin:discord', agentId: this.runtime.agentId, guildId: guild.id, memberCount: guild.memberCount.toLocaleString() }, 'Using optimized user sync for large guild');
 
       // For large guilds, prioritize members already in cache + online members
       try {
@@ -1984,39 +1986,22 @@ export class DiscordService extends Service implements IDiscordService {
     const auditLogSettingForInvite = this.runtime.getSetting('DISCORD_AUDIT_LOG_ENABLED');
     const isAuditLogEnabledForInvite = auditLogSettingForInvite !== 'false' && auditLogSettingForInvite !== false;
 
-    // Required permissions for the bot (least-privilege: only request what's needed)
-    const permissionsList: bigint[] = [
-      // Text Permissions
-      PermissionsBitField.Flags.ViewChannel,
-      PermissionsBitField.Flags.SendMessages,
-      PermissionsBitField.Flags.SendMessagesInThreads,
-      PermissionsBitField.Flags.CreatePrivateThreads,
-      PermissionsBitField.Flags.CreatePublicThreads,
-      PermissionsBitField.Flags.EmbedLinks,
-      PermissionsBitField.Flags.AttachFiles,
-      PermissionsBitField.Flags.AddReactions,
-      PermissionsBitField.Flags.UseExternalEmojis,
-      PermissionsBitField.Flags.UseExternalStickers,
-      PermissionsBitField.Flags.MentionEveryone,
-      PermissionsBitField.Flags.ManageMessages,
-      PermissionsBitField.Flags.ReadMessageHistory,
-      // Voice Permissions
-      PermissionsBitField.Flags.Connect,
-      PermissionsBitField.Flags.Speak,
-      PermissionsBitField.Flags.UseVAD,
-      PermissionsBitField.Flags.PrioritySpeaker,
-    ];
+    // Generate invite URL using centralized permission tiers (MODERATOR_VOICE is recommended default)
+    // Note: If audit log tracking is enabled (DISCORD_AUDIT_LOG_ENABLED), you may need to manually
+    // grant ViewAuditLog permission to the bot role after it joins, as this is an elevated permission
+    // that should be granted per-server rather than requested in the OAuth invite.
+    let inviteUrl = readyClient.user?.id
+      ? generateInviteUrl(readyClient.user.id, 'MODERATOR_VOICE')
+      : `https://discord.com/api/oauth2/authorize?client_id=${readyClient.user?.id}&permissions=${DiscordPermissionTiers.MODERATOR_VOICE}&scope=bot%20applications.commands`;
 
-    // Only request ViewAuditLog when audit tracking is enabled
+    // Log a note if audit log tracking is enabled
     if (isAuditLogEnabledForInvite) {
-      permissionsList.push(PermissionsBitField.Flags.ViewAuditLog);
+      this.runtime.logger.info({ src: 'plugin:discord', agentId: this.runtime.agentId }, 'Audit log tracking enabled - ensure bot has ViewAuditLog permission in server settings');
     }
 
-    const requiredPermissions = permissionsList.reduce((a, b) => a | b, 0n);
-
-    const inviteUrl = `https://discord.com/api/oauth2/authorize?client_id=${readyClient.user?.id}&permissions=${requiredPermissions}&scope=bot%20applications.commands`;
     // Use character name if available, otherwise fallback to username, then agentId
     const agentName = this.runtime.character.name || readyClient.user?.username || this.runtime.agentId;
+    this.runtime.logger.info({ src: 'plugin:discord', agentId: this.runtime.agentId, inviteUrl }, 'Bot invite URL generated');
 
     this.runtime.logger.info(`Use this URL to add the "${agentName}" bot to your Discord server: ${inviteUrl}`);
 
@@ -2158,7 +2143,7 @@ export class DiscordService extends Service implements IDiscordService {
       let members: Collection<string, GuildMember>;
 
       if (useCacheOnly) {
-        this.runtime.logger.debug({ src: 'plugin:discord', agentId: this.runtime.agentId, guildId: guild.id, memberCount: guild.memberCount }, 'Using cached members for large guild');
+        this.runtime.logger.debug({ src: 'plugin:discord', agentId: this.runtime.agentId, guildId: guild.id, memberCount: guild.memberCount.toLocaleString() }, 'Using cached members for large guild');
         members = guild.members.cache;
       } else {
         // For smaller guilds or when cache is not preferred, fetch members
@@ -2169,7 +2154,7 @@ export class DiscordService extends Service implements IDiscordService {
           } else {
             this.runtime.logger.debug({ src: 'plugin:discord', agentId: this.runtime.agentId, guildId: guild.id }, 'Fetching members for guild');
             members = await guild.members.fetch();
-            this.runtime.logger.debug({ src: 'plugin:discord', agentId: this.runtime.agentId, memberCount: members.size }, 'Fetched members');
+            this.runtime.logger.debug({ src: 'plugin:discord', agentId: this.runtime.agentId, memberCount: members.size.toLocaleString() }, 'Fetched members');
           }
         } catch (error) {
           this.runtime.logger.error({ src: 'plugin:discord', agentId: this.runtime.agentId, error: error instanceof Error ? error.message : String(error) }, 'Error fetching members');
@@ -2202,7 +2187,7 @@ export class DiscordService extends Service implements IDiscordService {
           displayName: member.displayName || member.user.username,
         }));
 
-      this.runtime.logger.debug({ src: 'plugin:discord', agentId: this.runtime.agentId, channelId: channel.id, memberCount: channelMembers.length }, 'Found members with channel access');
+      this.runtime.logger.debug({ src: 'plugin:discord', agentId: this.runtime.agentId, channelId: channel.id, memberCount: channelMembers.length.toLocaleString() }, 'Found members with channel access');
       return channelMembers;
     } catch (error) {
       this.runtime.logger.error({ src: 'plugin:discord', agentId: this.runtime.agentId, error: error instanceof Error ? error.message : String(error) }, 'Error fetching channel members');

--- a/src/service.ts
+++ b/src/service.ts
@@ -3209,6 +3209,12 @@ export class DiscordService extends Service implements IDiscordService {
       fromBot: message.author.bot,
       fromId: message.author.id,
       sourceId: entityId,
+      // Raw Discord IDs for cross-agent correlation (not transformed by createUniqueUuid)
+      discordMessageId: message.id,
+      discordChannelId: message.channel.id,
+      discordServerId: ('guild' in message.channel && message.channel.guild)
+        ? message.channel.guild.id
+        : message.guild?.id,
       tags: [] as string[],
       ...options?.extraMetadata,
     };

--- a/src/service.ts
+++ b/src/service.ts
@@ -1990,9 +1990,9 @@ export class DiscordService extends Service implements IDiscordService {
     // Note: If audit log tracking is enabled (DISCORD_AUDIT_LOG_ENABLED), you may need to manually
     // grant ViewAuditLog permission to the bot role after it joins, as this is an elevated permission
     // that should be granted per-server rather than requested in the OAuth invite.
-    let inviteUrl = readyClient.user?.id
+    const inviteUrl = readyClient.user?.id
       ? generateInviteUrl(readyClient.user.id, 'MODERATOR_VOICE')
-      : `https://discord.com/api/oauth2/authorize?client_id=${readyClient.user?.id}&permissions=${DiscordPermissionTiers.MODERATOR_VOICE}&scope=bot%20applications.commands`;
+      : undefined;
 
     // Log a note if audit log tracking is enabled
     if (isAuditLogEnabledForInvite) {
@@ -2001,9 +2001,13 @@ export class DiscordService extends Service implements IDiscordService {
 
     // Use character name if available, otherwise fallback to username, then agentId
     const agentName = this.runtime.character.name || readyClient.user?.username || this.runtime.agentId;
-    this.runtime.logger.info({ src: 'plugin:discord', agentId: this.runtime.agentId, inviteUrl }, 'Bot invite URL generated');
 
-    this.runtime.logger.info(`Use this URL to add the "${agentName}" bot to your Discord server: ${inviteUrl}`);
+    if (inviteUrl) {
+      this.runtime.logger.info({ src: 'plugin:discord', agentId: this.runtime.agentId, inviteUrl }, 'Bot invite URL generated');
+      this.runtime.logger.info(`Use this URL to add the "${agentName}" bot to your Discord server: ${inviteUrl}`);
+    } else {
+      this.runtime.logger.warn({ src: 'plugin:discord', agentId: this.runtime.agentId }, 'Could not generate invite URL - bot user ID unavailable');
+    }
 
     this.runtime.logger.success(`Discord client logged in successfully as ${readyClient.user?.username || agentName}`);
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -81,7 +81,7 @@ import { MessageManager } from './messages';
 
 import { DiscordEventTypes, type IDiscordService, type DiscordSettings, type DiscordSlashCommand, type ChannelHistoryOptions, type ChannelHistoryResult, type ChannelSpiderState } from './types';
 import { getAttachmentFileName, splitMessage, MAX_MESSAGE_LENGTH } from './utils';
-import { DiscordPermissionTiers, generateInviteUrl } from './permissions';
+import { generateInviteUrl } from './permissions';
 import { VoiceManager } from './voice';
 import {
   diffOverwrites,

--- a/src/types.ts
+++ b/src/types.ts
@@ -483,6 +483,7 @@ export interface IDiscordService {
       processedContent?: string;
       processedAttachments?: Media[];
       extraContent?: Record<string, any>;
+      extraMetadata?: Record<string, any>;
     }
   ) => Promise<Memory | null>;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -335,8 +335,9 @@ export async function sendMessageInChunks(
           content: message.trim(),
         };
 
+        // Reply to the specified message for the first chunk
         if (i === 0 && inReplyTo) {
-          // Reply to the specified message for the first chunk
+          // Enable reply threading for first message chunk if inReplyTo is provided
           options.reply = {
             messageReference: inReplyTo,
           };
@@ -451,8 +452,30 @@ export async function sendMessageInChunks(
           }
         }
 
-        const m = await channel.send(options);
-        sentMessages.push(m);
+        try {
+          const m = await channel.send(options);
+          sentMessages.push(m);
+        } catch (error: any) {
+          // Handle unknown message reference error
+          if (error?.code === 50035 && error?.message?.includes('Unknown message')) {
+            logger.warn(
+              `Message reference no longer valid (message may have been deleted). Sending without reply threading.`
+            );
+            // Retry without the reply reference
+            const optionsWithoutReply = { ...options };
+            delete optionsWithoutReply.reply;
+            try {
+              const m = await channel.send(optionsWithoutReply);
+              sentMessages.push(m);
+            } catch (retryError) {
+              logger.error(`Error sending message after removing reply reference: ${retryError}`);
+              throw retryError;
+            }
+          } else {
+            // Re-throw other errors
+            throw error;
+          }
+        }
       }
     }
   } catch (error) {


### PR DESCRIPTION
Add a 3x2 permission matrix for Discord bot invites:
- Role levels: Basic / Moderator / Admin
- Voice options: With Voice / Without Voice

Changes:
- Add src/permissions.ts with centralized permission tier definitions
- Enhance banner.ts with tiered invite URL display (🎙️/💬 sections)
- Update index.ts to use new banner with all settings displayed
- Refactor service.ts to use generateInviteUrl() instead of inline perms
- Add extraMetadata to buildMemoryFromMessage for cross-agent filtering
- Fix channelState/voiceState providers to handle both channelId and serverId
- Export permission utilities (DiscordPermissionTiers, generateInviteUrl, etc)

Permission tiers:
- Basic: text chat, reactions, embeds, threads, slash commands
- Moderator: + manage messages, mention everyone, polls, timeout
- Admin: + kick/ban, manage channels/roles/webhooks
- Voice addon: connect, speak, VAD, priority speaker, stream

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a centralized 3x2 Discord permission tier system with generated invite URLs, overhauls the settings banner, and updates actions/services to use new server ID handling and richer metadata.
> 
> - **Permissions/Invites**:
>   - Add `src/permissions.ts` with 3x2 tiers (Basic/Moderator/Admin × Voice/No Voice) and helpers (`generateInviteUrl`, `generateAllInviteUrls`, `getPermissionValues`).
>   - Replace inline permission math in `service.ts` with `generateInviteUrl('MODERATOR_VOICE')`; log invite URL and audit-log note.
>   - Export permission utilities from `index.ts`.
> - **Banner/UI**:
>   - Replace legacy banner with `printBanner` in `banner.ts` (ANSI overhaul, settings table, tiered invite links); keep `printDiscordBanner` for compatibility.
>   - Use new banner in `index.ts` and show all Discord settings.
> - **Actions/Server handling**:
>   - Use `room.messageServerId` fallback where applicable and fetch guild by resolved `serverId` in `getUserInfo`, `readChannel`, `searchMessages`, `serverInfo`.
>   - Improve `serverInfo` formatting (localized counts, sticker count).
> - **Messaging/Metadata**:
>   - Allow `extraMetadata` in `buildMemoryFromMessage` (`types.ts`), add reply attribution (`replyToAuthor`) and raw Discord IDs (`discordMessageId`, `discordChannelId`, `discordServerId`) in `messages.ts`/`service.ts`.
>   - `utils.sendMessageInChunks`: thread replies on first chunk; retry without reply if reference is invalid.
> - **Providers/Logging**:
>   - `voiceStateProvider`: include `roomType` in values when not in voice.
>   - Large-guild logs use localized member counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 218d3c3da21d05e7fd691a4a852a9ba6d4e30c9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tiered Discord permission presets and enhanced invite URL generation.
  * Expanded startup banner showing settings and invite matrix.
  * Message metadata now captures replied-to author for cross-agent filtering.

* **Improvements**
  * Locale-aware number formatting for counts.
  * Better server identification with fallback.
  * Added Discord IDs to memory for improved cross-entity correlation.
  * Automatic retry fallback when a reply reference is no longer valid.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->