### PR TITLE
fix(plugin-discord): bind proxy methods to target for private field a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-discord",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -22,43 +22,53 @@ import type { IAgentRuntime, UUID, World, Room, ChannelType, Entity } from '@eli
  * These allow TypeScript to accept messageServerId in object literals.
  */
 export type WorldCompat = Omit<World, 'serverId'> & {
-    serverId?: string;
-    messageServerId?: UUID;
+  serverId?: string;
+  messageServerId?: UUID;
 };
 
 export type RoomCompat = Omit<Room, 'serverId'> & {
-    serverId?: string;
-    messageServerId?: UUID;
+  serverId?: string;
+  messageServerId?: UUID;
 };
 
 export interface EnsureConnectionParams {
-    entityId: UUID;
-    roomId: UUID;
-    userName?: string;
-    name?: string;
-    worldName?: string;
-    source?: string;
-    channelId?: string;
-    serverId?: string;
-    messageServerId?: UUID;
-    type?: ChannelType | string;
-    worldId: UUID;
-    userId?: UUID;
-    metadata?: Record<string, unknown>;
+  entityId: UUID;
+  roomId: UUID;
+  userName?: string;
+  name?: string;
+  worldName?: string;
+  source?: string;
+  channelId?: string;
+  serverId?: string;
+  messageServerId?: UUID;
+  type?: ChannelType | string;
+  worldId: UUID;
+  userId?: UUID;
+  metadata?: Record<string, unknown>;
 }
 
 /**
  * Extended runtime interface that accepts messageServerId in method parameters.
  */
-export interface ICompatRuntime extends Omit<IAgentRuntime, 'ensureWorldExists' | 'ensureRoomExists' | 'ensureConnection' | 'ensureConnections'> {
-    ensureWorldExists(world: WorldCompat): Promise<void>;
-    ensureRoomExists(room: RoomCompat): Promise<void>;
-    ensureConnection(params: EnsureConnectionParams): Promise<void>;
-    ensureConnections(entities: Entity[], rooms: RoomCompat[], source: string, world: WorldCompat): Promise<void>;
+export interface ICompatRuntime extends Omit<
+  IAgentRuntime,
+  'ensureWorldExists' | 'ensureRoomExists' | 'ensureConnection' | 'ensureConnections'
+> {
+  ensureWorldExists(world: WorldCompat): Promise<void>;
+  ensureRoomExists(room: RoomCompat): Promise<void>;
+  ensureConnection(params: EnsureConnectionParams): Promise<void>;
+  ensureConnections(
+    entities: Entity[],
+    rooms: RoomCompat[],
+    source: string,
+    world: WorldCompat
+  ): Promise<void>;
 }
 
 function addServerId<T extends Record<string, unknown>>(obj: T): T {
-  if (!obj?.messageServerId) {return obj;}
+  if (!obj?.messageServerId) {
+    return obj;
+  }
   return { ...obj, serverId: obj.serverId ?? obj.messageServerId };
 }
 
@@ -66,15 +76,16 @@ export function createCompatRuntime(runtime: IAgentRuntime): ICompatRuntime {
   return new Proxy(runtime, {
     get(target, prop, receiver) {
       const value = Reflect.get(target, prop, receiver);
-      if (typeof value !== 'function') {return value;}
+      if (typeof value !== 'function') {
+        return value;
+      }
 
       if (prop === 'ensureWorldExists') {
         return (world: unknown) =>
           value.call(target, addServerId(world as Record<string, unknown>));
       }
       if (prop === 'ensureRoomExists') {
-        return (room: unknown) =>
-          value.call(target, addServerId(room as Record<string, unknown>));
+        return (room: unknown) => value.call(target, addServerId(room as Record<string, unknown>));
       }
       if (prop === 'ensureConnection') {
         return (params: unknown) =>
@@ -91,8 +102,8 @@ export function createCompatRuntime(runtime: IAgentRuntime): ICompatRuntime {
           );
       }
 
-      return value;
+      // Bind all other methods to target so private fields (like #conversationLength) work
+      return value.bind(target);
     },
   });
 }
-


### PR DESCRIPTION
When createCompatRuntime wraps the runtime in a Proxy, methods returned
without binding have `this` set to the proxy instead of the original
AgentRuntime. This breaks access to private fields like #conversationLength,
causing "Cannot access invalid private field" errors in providers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes method binding in compatibility proxy**
> 
> - In `src/compat.ts`, updates `createCompatRuntime` to bind all non-overridden methods to the original runtime target, ensuring `this` is correct for accessing private fields (e.g., `#conversationLength`).
> - Keeps special handling for `ensureWorldExists`, `ensureRoomExists`, `ensureConnection`, and `ensureConnections` while maintaining `serverId`/`messageServerId` compatibility.
> - Bumps package version to `1.3.8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be0ef8c22b7f51b404c74f5bc29bafe58b2de899. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed a critical bug in the runtime compatibility layer where proxy-intercepted methods lost their `this` context, causing "Cannot access invalid private field" errors when accessing private fields like `#conversationLength`.

**Key Changes:**
- Added `.bind(target)` to all non-intercepted runtime methods in the proxy's `get` trap
- Ensures methods maintain correct `this` binding to the original `AgentRuntime` instance instead of the proxy
- Preserves access to private class fields that are not accessible from proxy context
- Also includes code formatting improvements (indentation consistency)

**Impact:**
- Resolves runtime errors in actions like `transcribeMedia` and `chatWithAttachments` that call `runtime.getConversationLength()`
- Maintains backward compatibility while fixing the proxy delegation issue
- No breaking changes to the API surface

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified risks
- The fix correctly addresses a well-understood JavaScript/TypeScript proxy behavior issue with a standard solution (binding methods to their original context). The change is minimal, focused, and preserves all existing functionality while fixing the private field access bug. The formatting changes are cosmetic improvements that increase code consistency.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/compat.ts | Fixed proxy method binding to preserve `this` context for private field access, preventing "Cannot access invalid private field" errors when runtime methods access private fields like `#conversationLength` |
| package.json | Version bump from 1.3.7 to 1.3.8 for patch release |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Plugin Code
    participant Proxy as createCompatRuntime Proxy
    participant Target as AgentRuntime
    participant PrivateField as #conversationLength

    Note over Client,PrivateField: Before Fix: Method calls lose context
    Client->>Proxy: runtime.getConversationLength()
    Proxy->>Proxy: get trap intercepts access
    Proxy->>Target: Reflect.get(target, 'getConversationLength', receiver)
    Note over Proxy: Returns unbound function<br/>with this = proxy
    Proxy-->>Client: Returns unbound function
    Client->>Proxy: Call function
    Proxy->>PrivateField: Try to access #conversationLength
    PrivateField-->>Proxy: ❌ Error: Cannot access invalid private field
    
    Note over Client,PrivateField: After Fix: Methods bound to target
    Client->>Proxy: runtime.getConversationLength()
    Proxy->>Proxy: get trap intercepts access
    Proxy->>Target: Reflect.get(target, 'getConversationLength', receiver)
    Proxy->>Proxy: value.bind(target)
    Note over Proxy: Binds this = target (AgentRuntime)
    Proxy-->>Client: Returns bound function
    Client->>Target: Call bound function
    Target->>PrivateField: Access #conversationLength
    PrivateField-->>Target: ✅ Returns conversation length
    Target-->>Client: Returns value
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->