### PR TITLE
fix: respect explicit MILADY_DISCORD_OWNER_USER_IDS_JSON setting

### DIFF
--- a/typescript/service.ts
+++ b/typescript/service.ts
@@ -213,24 +213,34 @@ export class DiscordService extends Service implements IDiscordService {
 	private async refreshOwnerDiscordUserIds(
 		client: DiscordJsClient,
 	): Promise<void> {
-		const configuredOwnerIds = parseDiscordOwnerUserIds(
-			this.runtime.getSetting?.("MILADY_DISCORD_OWNER_USER_IDS_JSON"),
+		const explicitSetting = this.runtime.getSetting?.(
+			"MILADY_DISCORD_OWNER_USER_IDS_JSON",
 		);
-		const application =
-			client.application && typeof client.application.fetch === "function"
-				? await client.application.fetch()
-				: client.application;
-		const ownerIds = [
-			...new Set([
-				...configuredOwnerIds,
-				...extractDiscordOwnerUserIds(application),
-			]),
-		];
+		const hasExplicitSetting =
+			typeof explicitSetting === "string" && explicitSetting.trim().length > 0;
+
+		let ownerIds: string[];
+		if (hasExplicitSetting) {
+			// When the deployer explicitly sets MILADY_DISCORD_OWNER_USER_IDS_JSON
+			// (even to an empty array), respect it as the full owner list. The
+			// auto-detected discord application owner is only a fallback for
+			// deployments that haven't pinned the canonical owner mapping themselves.
+			// This avoids surprising remap-to-admin-entity behavior for users whose
+			// discord account happens to own the bot's application.
+			ownerIds = parseDiscordOwnerUserIds(explicitSetting);
+		} else {
+			const application =
+				client.application && typeof client.application.fetch === "function"
+					? await client.application.fetch()
+					: client.application;
+			ownerIds = [...new Set(extractDiscordOwnerUserIds(application))];
+		}
+
+		this.ownerDiscordUserIds = new Set(ownerIds);
 		if (ownerIds.length === 0) {
 			return;
 		}
 
-		this.ownerDiscordUserIds = new Set(ownerIds);
 		const existingWhitelist = getConnectorAdminWhitelist(this.runtime);
 		const nextDiscordAdmins = [
 			...new Set([...(existingWhitelist.discord ?? []), ...ownerIds]),
@@ -241,6 +251,7 @@ export class DiscordService extends Service implements IDiscordService {
 			...existingWhitelist,
 			discord: nextDiscordAdmins,
 		});
+
 		this.runtime.logger.info(
 			{
 				src: "plugin:discord",


### PR DESCRIPTION
## what

refactors \`refreshOwnerDiscordUserIds\` to honor an explicit \`MILADY_DISCORD_OWNER_USER_IDS_JSON\` runtime setting. when the deployer pins the canonical owner mapping (even to an empty array), skip the auto-fetched discord application owner fallback.

## why

before this change, anyone whose personal discord account also owned the bot's discord application got automatically promoted to canonical owner. that's a surprise remap-to-admin-entity for solo deployers who happen to manage their own application from their personal account. opt-out via empty array (\`"[]"\`) is now possible without losing the application-owner fallback for deployments that want it.

## how

- new branch checks the setting first via \`runtime.getSetting?.(...)\`, parses the JSON array via the existing \`parseDiscordOwnerUserIds\` helper, falls back to the existing application-owner extraction only when the setting is unset
- the existing \`setConnectorAdminWhitelist\` call (introduced on alpha) is preserved on top of the rebased branch so the canonical owner mapping still flows through to runtime role checks for deployments that don't opt out
- factored out an \`application\` const inside the closure for readability (was an inlined ternary inside the array spread)

## testing

- explicit empty array \`"[]"\` → no auto-mapping, no canonical owner override (verified via local bot startup logs: no \"Resolved Discord owner identities\" line)
- explicit single id \`"[\\"123...\\"]"\` → that id becomes the canonical owner
- unset → existing application-owner behavior unchanged
- typecheck clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Discord owner/admin identities are derived, which can affect authorization/role checks and who is treated as a connector admin. Risk is mitigated by keeping behavior the same when the setting is unset and only altering explicit-setting deployments.
> 
> **Overview**
> Updates `refreshOwnerDiscordUserIds` to **treat `MILADY_DISCORD_OWNER_USER_IDS_JSON` as the authoritative owner list when explicitly provided**, including allowing an explicit empty array to disable auto-detected owners.
> 
> When the setting is not provided, it continues to fall back to fetching the Discord application owner(s), then synchronizes the resolved owner IDs into the connector admin whitelist without overwriting other configured admins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04257a8468e209ac5ab44edac24120281d900946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord owner ID detection to prioritize explicit configuration values. When configured, the system uses the provided owner list directly. When configuration is absent, it automatically detects owners from Discord application data, ensuring consistent and reliable owner identification across all deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `refreshOwnerDiscordUserIds` so an explicit `MILADY_DISCORD_OWNER_USER_IDS_JSON` setting takes full precedence over the auto-detected application-owner fallback, rather than being merged with it. Deployers can now opt out entirely by setting the value to `"[]"`.

- The move of `this.ownerDiscordUserIds = new Set(ownerIds)` to before the early-return is a deliberate semantic change: an explicit empty-array opt-out now actively clears the owner set rather than leaving a prior value in place. Since `refreshOwnerDiscordUserIds` is only called once (in `onReady`), this has no practical regression risk.
- When `ownerIds` is empty the `setConnectorAdminWhitelist` call is skipped (matching the original early-return guard), so previously configured non-Discord admins are unaffected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, well-scoped, and all three advertised cases (explicit list, explicit empty array, unset) behave as documented.

No P0 or P1 issues found. The logic is correct for every documented scenario: explicit non-empty list uses only those IDs; explicit empty array `"[]"` opts out without touching the whitelist; unset falls back to the existing application-owner path. `getSetting` consistently returns strings in this codebase, so the `typeof === "string"` guard in `hasExplicitSetting` is appropriate. The one semantic shift (setting `ownerDiscordUserIds` before the early return) is intentional and has no regression risk since `refreshOwnerDiscordUserIds` is called only once per client lifecycle.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| typescript/service.ts | Correctly branches on explicit setting vs. fallback; `ownerDiscordUserIds` is now set unconditionally before the early return, which is intentional for the opt-out case. No regressions found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["refreshOwnerDiscordUserIds(client)"] --> B{"getSetting\n'MILADY_DISCORD_OWNER_USER_IDS_JSON'"}
    B -->|"non-empty string\n(explicit)"| C["parseDiscordOwnerUserIds(explicitSetting)"]
    B -->|"null / undefined /\nwhitespace-only"| D["client.application.fetch()"]
    D --> E["extractDiscordOwnerUserIds(application)"]
    C --> F["ownerIds"]
    E --> F
    F --> G["this.ownerDiscordUserIds = new Set(ownerIds)"]
    G --> H{"ownerIds.length === 0?"}
    H -->|yes| I["return early\n(no whitelist update, no log)"]
    H -->|no| J["getConnectorAdminWhitelist"]
    J --> K["merge existing discord admins + ownerIds"]
    K --> L["setConnectorAdminWhitelist"]
    L --> M["logger.info — Resolved Discord owner identities"]
```

<sub>Reviews (1): Last reviewed commit: ["fix: respect explicit MILADY\_DISCORD\_OWN..."](https://github.com/elizaos-plugins/plugin-discord/commit/04257a8468e209ac5ab44edac24120281d900946) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28066076)</sub>

<!-- /greptile_comment -->