### PR TITLE
fix(discord): safer defaults, DM allowlist gating, and generation timeout fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,15 @@ DISCORD_LISTEN_CHANNEL_IDS=123456789012345678
 DISCORD_VOICE_CHANNEL_ID=123456789012345678
 
 # Behavior Settings (Optional)
-# If true, ignore messages from other bots (default: false)
-DISCORD_SHOULD_IGNORE_BOT_MESSAGES=false
+# If true, ignore messages from other bots (default: true)
+DISCORD_SHOULD_IGNORE_BOT_MESSAGES=true
 
-# If true, ignore direct messages (default: false)
-DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES=false
+# If true, ignore direct messages by default (default: true).
+# DMs can still be allowed explicitly via DISCORD_ALLOW_FROM / pairing allowlist.
+DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES=true
 
-# If true, only respond when explicitly @mentioned (default: false)
-DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS=false
+# If true, only respond when explicitly @mentioned (default: true)
+DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS=true
 
 # Testing (Optional)
 DISCORD_TEST_CHANNEL_ID=123456789012345678
@@ -70,9 +71,9 @@ Settings can also be configured in your character file under `settings.discord`:
 {
   "settings": {
     "discord": {
-      "shouldIgnoreBotMessages": false,
-      "shouldIgnoreDirectMessages": false,
-      "shouldRespondOnlyToMentions": false,
+      "shouldIgnoreBotMessages": true,
+      "shouldIgnoreDirectMessages": true,
+      "shouldRespondOnlyToMentions": true,
       "allowedChannelIds": ["123456789012345678"]
     }
   }

--- a/typescript/accounts.ts
+++ b/typescript/accounts.ts
@@ -225,6 +225,30 @@ function filterDefined<T extends object>(obj: T): Partial<T> {
 	) as Partial<T>;
 }
 
+function parseOptionalBooleanSetting(
+	runtime: IAgentRuntime,
+	key: string,
+): boolean | undefined {
+	const value = runtime.getSetting(key);
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value === "boolean") {
+		return value;
+	}
+	const normalized = String(value).trim().toLowerCase();
+	if (!normalized) {
+		return undefined;
+	}
+	if (normalized === "true" || normalized === "1") {
+		return true;
+	}
+	if (normalized === "false" || normalized === "0") {
+		return false;
+	}
+	return undefined;
+}
+
 /**
  * Merges base configuration with account-specific overrides
  */
@@ -243,18 +267,18 @@ function mergeDiscordAccountConfig(
 	) as string | undefined;
 
 	const envConfig: DiscordAccountConfig = {
-		shouldIgnoreBotMessages:
-			(
-				runtime.getSetting("DISCORD_SHOULD_IGNORE_BOT_MESSAGES") as string
-			)?.toLowerCase() === "true",
-		shouldIgnoreDirectMessages:
-			(
-				runtime.getSetting("DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES") as string
-			)?.toLowerCase() === "true",
-		shouldRespondOnlyToMentions:
-			(
-				runtime.getSetting("DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS") as string
-			)?.toLowerCase() === "true",
+		shouldIgnoreBotMessages: parseOptionalBooleanSetting(
+			runtime,
+			"DISCORD_SHOULD_IGNORE_BOT_MESSAGES",
+		),
+		shouldIgnoreDirectMessages: parseOptionalBooleanSetting(
+			runtime,
+			"DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES",
+		),
+		shouldRespondOnlyToMentions: parseOptionalBooleanSetting(
+			runtime,
+			"DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS",
+		),
 		channelIds: envChannelIds
 			? envChannelIds
 					.split(",")

--- a/typescript/environment.ts
+++ b/typescript/environment.ts
@@ -25,15 +25,15 @@ function getEnvArray(name: string, fallback: string[]): string[] {
 export const DISCORD_DEFAULTS = {
 	SHOULD_IGNORE_BOT_MESSAGES: getEnvBoolean(
 		"DISCORD_SHOULD_IGNORE_BOT_MESSAGES",
-		false,
+		true,
 	),
 	SHOULD_IGNORE_DIRECT_MESSAGES: getEnvBoolean(
 		"DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES",
-		false,
+		true,
 	),
 	SHOULD_RESPOND_ONLY_TO_MENTIONS: getEnvBoolean(
 		"DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS",
-		false,
+		true,
 	),
 	ALLOWED_CHANNEL_IDS: getEnvArray("CHANNEL_IDS", []),
 	DM_POLICY: (process.env?.DISCORD_DM_POLICY || "pairing") as

--- a/typescript/messages.ts
+++ b/typescript/messages.ts
@@ -325,15 +325,22 @@ export class MessageManager {
 			return;
 		}
 
-		if (
-			this.discordSettings.shouldIgnoreDirectMessages &&
-			message.channel.type === DiscordChannelType.DM
-		) {
-			return;
-		}
-
 		// DM policy check - applies access control policies for direct messages
 		if (message.channel.type === DiscordChannelType.DM) {
+			const userId = message.author.id;
+			if (this.discordSettings.shouldIgnoreDirectMessages) {
+				const staticallyAllowed =
+					this.discordSettings.allowFrom?.includes(userId) === true;
+				const dynamicallyAllowed = await isInAllowlist(
+					this.runtime,
+					"discord",
+					userId,
+				);
+				if (!staticallyAllowed && !dynamicallyAllowed) {
+					return;
+				}
+			}
+
 			const accessCheck = await this.checkDmAccess(message);
 			if (!accessCheck.allowed) {
 				// If a reply message was generated (new pairing request), send it
@@ -629,6 +636,18 @@ export class MessageManager {
 				: null;
 			let typingStarted = false;
 			let responseEmitted = false;
+			let generationTimedOut = false;
+			const generationTimeoutMs = Math.max(
+				30_000,
+				Number.parseInt(
+					String(
+						this.runtime.getSetting("DISCORD_GENERATION_TIMEOUT_MS") ??
+							this.runtime.getSetting("MESSAGE_TIMEOUT_MS") ??
+							"120000",
+					),
+					10,
+				) || 120_000,
+			);
 
 			const finalizePendingDraft = async () => {
 				if (draftStream?.isStarted() && !draftStream.isDone()) {
@@ -640,6 +659,34 @@ export class MessageManager {
 				if (draftStream?.isStarted() && !draftStream.isDone()) {
 					await draftStream.abort(
 						"An error occurred while generating the response.",
+					);
+				}
+			};
+
+			const sendFailureReply = async (text: string) => {
+				try {
+					await channel.send({
+						content: text,
+						...(outboundReplyToMessageId && replyToMode !== "off"
+							? {
+									reply: {
+										messageReference: outboundReplyToMessageId,
+									},
+								}
+							: {}),
+					});
+					responseEmitted = true;
+				} catch (sendError) {
+					this.runtime.logger.warn(
+						{
+							src: "plugin:discord",
+							agentId: this.runtime.agentId,
+							error:
+								sendError instanceof Error
+									? sendError.message
+									: String(sendError),
+						},
+						"Failed to send Discord failure reply",
 					);
 				}
 			};
@@ -663,6 +710,9 @@ export class MessageManager {
 
 			const callback: HandlerCallback = async (content: Content) => {
 				try {
+					if (generationTimedOut) {
+						return [];
+					}
 					// target is set but not addressed to us handling
 					if (
 						content.target &&
@@ -932,40 +982,87 @@ export class MessageManager {
 
 			const messagingAPI = getMessagingAPI(this.runtime);
 			const messageService = getMessageService(this.runtime);
+			let generationTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+			try {
+				const generationPromise = (async () => {
+					if (messageService) {
+						this.runtime.logger.debug(
+							{ src: "plugin:discord", agentId: this.runtime.agentId },
+							"Using messageService API",
+						);
+						await messageService.handleMessage(this.runtime, newMessage, callback);
+					} else if (messagingAPI?.handleMessage) {
+						this.runtime.logger.debug(
+							{ src: "plugin:discord", agentId: this.runtime.agentId },
+							"Using messaging API handleMessage",
+						);
+						await messagingAPI.handleMessage(this.runtime.agentId, newMessage, {
+							onResponse: callback,
+						});
+					} else if (messagingAPI?.sendMessage) {
+						this.runtime.logger.debug(
+							{ src: "plugin:discord", agentId: this.runtime.agentId },
+							"Using messaging API sendMessage",
+						);
+						await messagingAPI.sendMessage(this.runtime.agentId, newMessage, {
+							onResponse: callback,
+						});
+					} else {
+						this.runtime.logger.debug(
+							{ src: "plugin:discord", agentId: this.runtime.agentId },
+							"Using event-based message handling",
+						);
+						await this.runtime.emitEvent([EventType.MESSAGE_RECEIVED], {
+							runtime: this.runtime,
+							message: newMessage,
+							callback,
+							source: "discord",
+						});
+					}
+				})();
 
-			if (messageService) {
-				this.runtime.logger.debug(
-					{ src: "plugin:discord", agentId: this.runtime.agentId },
-					"Using messageService API",
-				);
-				await messageService.handleMessage(this.runtime, newMessage, callback);
-			} else if (messagingAPI?.handleMessage) {
-				this.runtime.logger.debug(
-					{ src: "plugin:discord", agentId: this.runtime.agentId },
-					"Using messaging API handleMessage",
-				);
-				await messagingAPI.handleMessage(this.runtime.agentId, newMessage, {
-					onResponse: callback,
+				const timeoutPromise = new Promise<never>((_, reject) => {
+					generationTimeoutHandle = setTimeout(() => {
+						generationTimedOut = true;
+						reject(
+							new Error(
+								`Discord generation timeout after ${generationTimeoutMs}ms`,
+							),
+						);
+					}, generationTimeoutMs);
 				});
-			} else if (messagingAPI?.sendMessage) {
-				this.runtime.logger.debug(
-					{ src: "plugin:discord", agentId: this.runtime.agentId },
-					"Using messaging API sendMessage",
+
+				await Promise.race([generationPromise, timeoutPromise]);
+			} catch (generationError) {
+				this.runtime.logger.error(
+					{
+						src: "plugin:discord",
+						agentId: this.runtime.agentId,
+						messageId: message.id,
+						timeoutMs: generationTimeoutMs,
+						error:
+							generationError instanceof Error
+								? generationError.message
+								: String(generationError),
+					},
+					"Discord generation failed or timed out",
 				);
-				await messagingAPI.sendMessage(this.runtime.agentId, newMessage, {
-					onResponse: callback,
-				});
-			} else {
-				this.runtime.logger.debug(
-					{ src: "plugin:discord", agentId: this.runtime.agentId },
-					"Using event-based message handling",
-				);
-				await this.runtime.emitEvent([EventType.MESSAGE_RECEIVED], {
-					runtime: this.runtime,
-					message: newMessage,
-					callback,
-					source: "discord",
-				});
+				typingController.stop();
+				statusReactions?.setError();
+				await abortPendingDraft();
+
+				if (!responseEmitted) {
+					await sendFailureReply(
+						generationTimedOut
+							? "I timed out while generating that reply. Please retry."
+							: "I hit a provider issue while generating the reply. Please retry.",
+					);
+				}
+				return;
+			} finally {
+				if (generationTimeoutHandle) {
+					clearTimeout(generationTimeoutHandle);
+				}
 			}
 
 			if (!responseEmitted) {

--- a/typescript/messages.ts
+++ b/typescript/messages.ts
@@ -1032,6 +1032,7 @@ export class MessageManager {
 					}, generationTimeoutMs);
 				});
 
+				generationPromise.catch(() => {});
 				await Promise.race([generationPromise, timeoutPromise]);
 			} catch (generationError) {
 				this.runtime.logger.error(


### PR DESCRIPTION
## Summary\n- default to safer Discord behavior flags\n- parse optional boolean env settings robustly\n- allow DM processing for explicit allowlist users even when DM-ignore default is enabled\n- add generation timeout/failure fallback reply to avoid stuck typing state\n\n## Why\nImproves Discord reliability and prevents silent hangs during provider timeouts/failures.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces three improvements: changes default behavior flags (`shouldIgnoreBotMessages`, `shouldIgnoreDirectMessages`, `shouldRespondOnlyToMentions`) from `false` to `true` for safer defaults; allows explicit allowlisted users to bypass the DM-ignore gate while still subject to `dmPolicy`; and wraps message generation in a `Promise.race` timeout to prevent stuck typing state and send a user-facing fallback reply.

- **Unhandled promise rejection after timeout**: `generationPromise` runs as a detached in-flight promise once the timeout race wins. If the underlying handler subsequently rejects (network error, provider crash), Node.js 15+ will treat this as an uncaught exception and can terminate the process. The fix is to attach `.catch(() => {})` to `generationPromise` before or after the race so the late rejection is silently swallowed.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the detached-promise unhandled-rejection risk, which can crash the bot process under a provider failure that follows a timeout.

One P1 finding: the `generationPromise` is left without a rejection handler after `Promise.race` resolves on timeout, creating a potential process-terminating unhandled rejection in Node 15+. The fix is a one-liner. All other changes (safer defaults, DM allowlist bypass, `parseOptionalBooleanSetting`) are clean and correct.

typescript/messages.ts — specifically the `Promise.race` block around line 1035 and the error-reaction guard in the catch block.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| typescript/messages.ts | Adds DM allowlist bypass for `shouldIgnoreDirectMessages` and wraps generation in a `Promise.race` timeout; the detached `generationPromise` can produce an unhandled rejection if the handler fails after the timeout fires. |
| typescript/accounts.ts | Adds `parseOptionalBooleanSetting` to return `undefined` when env var is unset, allowing proper fallback to `DISCORD_DEFAULTS`; clean and correct change. |
| typescript/environment.ts | Changes three boolean defaults from `false` to `true` — intentional breaking change to safer defaults; no logic errors introduced. |
| README.md | Documentation updated to reflect new default values and DM allowlist behavior; accurate and consistent with code changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Discord Message] --> B{Is DM channel?}
    B -- No --> G{shouldRespondOnlyToMentions?}
    B -- Yes --> C{shouldIgnoreDirectMessages?}
    C -- No --> E[checkDmAccess]
    C -- Yes --> D{In allowFrom\nor isInAllowlist?}
    D -- No --> SKIP[return — ignore]
    D -- Yes --> E
    E -- not allowed --> F{Has reply message?}
    F -- Yes --> SEND_PAIR[Send pairing reply]
    F -- No --> SKIP
    SEND_PAIR --> SKIP
    E -- allowed --> G
    G -- strict + not mentioned --> SKIP
    G -- pass --> H[Build newMessage]
    H --> I[Promise.race: generationPromise vs timeoutPromise]
    I -- success --> J{responseEmitted?}
    J -- No --> K[finalizePendingDraft / setDone]
    J -- Yes --> END[done]
    K --> END
    I -- timeout/error --> L[stopTyping / setError / abortDraft]
    L --> M{responseEmitted?}
    M -- No --> N[sendFailureReply]
    M -- Yes --> END
    N --> END
```

<sub>Reviews (1): Last reviewed commit: ["fix(discord): safer defaults, dm allowli..."](https://github.com/elizaos-plugins/plugin-discord/commit/b4c999b9522fc0228383dffa8979e3f08a5b7906) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28436749)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->